### PR TITLE
fix: set session cookie in sign-in endpoints

### DIFF
--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -1,3 +1,4 @@
+import { setSessionCookie } from "better-auth/cookies";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createOrUpdateUser, firebaseAuthPlugin } from "./firebase-auth-plugin";
 
@@ -20,6 +21,10 @@ vi.mock("firebase/auth", () => ({
 	confirmPasswordReset: vi.fn(),
 	verifyPasswordResetCode: vi.fn(),
 	updateProfile: vi.fn(),
+}));
+
+vi.mock("better-auth/cookies", () => ({
+	setSessionCookie: vi.fn().mockResolvedValue(undefined),
 }));
 
 describe("firebaseAuthPlugin", () => {
@@ -89,6 +94,7 @@ describe("firebaseAuthPlugin", () => {
 		mockInternalAdapter.updateAccount.mockResolvedValue(mockAccount);
 		mockInternalAdapter.createSession.mockResolvedValue(mockSession);
 		mockAdminAuth.verifyIdToken.mockResolvedValue(mockDecodedToken);
+		vi.mocked(setSessionCookie).mockResolvedValue(undefined);
 	});
 
 	// ─── Plugin Initialization ───────────────────────────────────────────
@@ -203,6 +209,17 @@ describe("firebaseAuthPlugin", () => {
 				expect(sessionArgs[0]).toBe("user-123");
 				expect(sessionArgs[1]).toBeUndefined();
 				expect(sessionArgs[2].expiresAt).toBeInstanceOf(Date);
+			});
+
+			it("should call setSessionCookie with session and user after creating session", async () => {
+				const ctx = createMockCtx();
+				await createOrUpdateUser(ctx as any, mockDecodedToken, "id-token-abc");
+
+				expect(setSessionCookie).toHaveBeenCalledOnce();
+				expect(setSessionCookie).toHaveBeenCalledWith(ctx, {
+					session: mockSession,
+					user: mockUser,
+				});
 			});
 
 			it("should return correct response shape", async () => {
@@ -555,6 +572,7 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockAdminAuth.verifyIdToken.mockResolvedValue(mockDecodedToken);
+		vi.mocked(setSessionCookie).mockResolvedValue(undefined);
 	});
 
 	it("should sign in with Google and create user + session in DB", async () => {
@@ -584,6 +602,7 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 		expect(data.user.name).toBe("Integration User");
 		expect(data.session).toBeDefined();
 		expect(data.session.token).toBeDefined();
+		expect(setSessionCookie).toHaveBeenCalledOnce();
 	});
 
 	it("should sign in with email (client-side token mode) and create user", async () => {
@@ -611,6 +630,7 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 		const data = res.data as any;
 		expect(data.user.email).toBe("integration@example.com");
 		expect(data.session.token).toBeDefined();
+		expect(setSessionCookie).toHaveBeenCalledOnce();
 	});
 
 	it("should return same user on second sign-in (idempotent)", async () => {

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -4,6 +4,7 @@ import {
 	createAuthEndpoint,
 	createAuthMiddleware,
 } from "better-auth/api";
+import { setSessionCookie } from "better-auth/cookies";
 import type { FirebaseOptions } from "firebase/app";
 import { getAuth } from "firebase-admin/auth";
 import type { AuthResponse, FirebaseAuthPluginOptions } from "./types";
@@ -83,6 +84,8 @@ export const createOrUpdateUser = async (
 			),
 		},
 	);
+
+	await setSessionCookie(ctx, { session, user });
 
 	return {
 		user: {


### PR DESCRIPTION
## Problem

The `signInWithGoogle` and `signInWithEmail` endpoints correctly create a better-auth session in the database via `internalAdapter.createSession`, but they never call `setSessionCookie`. This means the browser never receives a session cookie after sign-in, so all subsequent authenticated requests fail — the user appears signed out immediately after logging in.

## Fix

Import `setSessionCookie` from `better-auth/cookies` and call it inside `createOrUpdateUser` after the session is created, passing the full `session` and `user` objects:

```ts
import { setSessionCookie } from 'better-auth/cookies';

// inside createOrUpdateUser, after internalAdapter.createSession(...)
await setSessionCookie(ctx, { session, user });
```

This is the same pattern used by other better-auth built-in plugins (e.g. `magic-link`, `anonymous`, `one-tap`). E.g. https://github.com/better-auth/better-auth/blob/f785113c5e6f0e002ce998cfb35e620792cfe458/packages/better-auth/src/plugins/one-tap/index.ts#L141

## Testing

<img width="702" height="158" alt="image" src="https://github.com/user-attachments/assets/ef9faebe-31d4-4433-b09c-78957526cc0f" />

