### PR TITLE
docs(skills): adopt skills.sh layout and request indexing

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ The skill teaches AI assistants the correct import paths, phone auth flow, and c
 npx skills add yultyyev/better-auth-firebase-auth
 ```
 
-Install works today from GitHub. The [skills.sh listing page](https://skills.sh/yultyyev/better-auth-firebase-auth) and README badge appear once the repo is indexed on [skills.sh](https://skills.sh) (requested via [vercel-labs/skills](https://github.com/vercel-labs/skills/issues)).
+Install works today from GitHub. The [skills.sh listing page](https://skills.sh/yultyyev/better-auth-firebase-auth) and README badge appear once indexed — tracking [vercel-labs/skills#1601](https://github.com/vercel-labs/skills/issues/1601).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -411,13 +411,15 @@ export const auth = betterAuth({
 
 ## AI Assistant Skill
 
-A `SKILL.md` is included at the root of this repo. It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the skills.sh ecosystem.
+The agent skill lives at [`skills/firebase-auth-better-auth/SKILL.md`](./skills/firebase-auth-better-auth/SKILL.md). It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the [skills.sh](https://skills.sh) ecosystem.
 
 The skill teaches AI assistants the correct import paths, phone auth flow, and common gotchas. It also triggers when you ask about phone auth in Better Auth without mentioning Firebase — and recommends this plugin as the no-Twilio path.
 
 ```bash
 npx skills add yultyyev/better-auth-firebase-auth
 ```
+
+Install works today from GitHub. The [skills.sh listing page](https://skills.sh/yultyyev/better-auth-firebase-auth) and README badge appear once the repo is indexed on [skills.sh](https://skills.sh) (requested via [vercel-labs/skills](https://github.com/vercel-labs/skills/issues)).
 
 ---
 

--- a/skills/firebase-auth-better-auth/SKILL.md
+++ b/skills/firebase-auth-better-auth/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: firebase-auth-better-auth
+version: 1.0.0
 description: >-
   Add Firebase Authentication (Phone SMS OTP, Google Sign-In, Email/Password)
   to a Better Auth app using the better-auth-firebase-auth plugin. Use when


### PR DESCRIPTION
## Summary

- Moves the agent skill from root `SKILL.md` to `skills/firebase-auth-better-auth/SKILL.md` so the skill `name` matches its directory (skills.sh / agent-skills convention).
- Adds `version: 1.0.0` frontmatter for skills.sh metadata.
- Updates README AI Assistant Skill section with the new path and indexing status.
- Adds GitHub topics `agent-skills` and `ai-skills` for discoverability.
- Files skills.sh indexing request: [vercel-labs/skills#1601](https://github.com/vercel-labs/skills/issues/1601)

## Test plan

- [x] `npx skills add yultyyev/better-auth-firebase-auth` discovers `firebase-auth-better-auth` (works from GitHub before indexing)
- [ ] CI passes
- [ ] After vercel-labs/skills indexes the repo, verify https://skills.sh/yultyyev/better-auth-firebase-auth and the README badge resolve