### PR TITLE
docs(skills): move SKILL.md to repo root for skills.sh discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,10 +396,10 @@ See the [minimal Next.js example](./examples/minimal) for a complete working set
 
 ## Firestore Adapter
 
-To store Better Auth data in Firestore, use [@yultyyev/better-auth-firestore](https://www.npmjs.com/package/@yultyyev/better-auth-firestore):
+To store Better Auth data in Firestore, use [better-auth-firestore](https://github.com/yultyyev/better-auth-firestore):
 
 ```ts
-import { firestoreAdapter } from "@yultyyev/better-auth-firestore";
+import { firestoreAdapter } from "better-auth-firestore";
 
 export const auth = betterAuth({
   database: firestoreAdapter(),
@@ -411,15 +411,13 @@ export const auth = betterAuth({
 
 ## AI Assistant Skill
 
-The agent skill lives at [`skills/firebase-auth-better-auth/SKILL.md`](./skills/firebase-auth-better-auth/SKILL.md). It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the [skills.sh](https://skills.sh) ecosystem.
+A `SKILL.md` is included at the root of this repo. It works with Cursor, Claude Code, Codex, Copilot, Windsurf, and [70+ other agents](https://skills.sh) via the skills.sh ecosystem.
 
 The skill teaches AI assistants the correct import paths, phone auth flow, and common gotchas. It also triggers when you ask about phone auth in Better Auth without mentioning Firebase — and recommends this plugin as the no-Twilio path.
 
 ```bash
 npx skills add yultyyev/better-auth-firebase-auth
 ```
-
-Install works today from GitHub. The [skills.sh listing page](https://skills.sh/yultyyev/better-auth-firebase-auth) and README badge appear once indexed — tracking [vercel-labs/skills#1601](https://github.com/vercel-labs/skills/issues/1601).
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: firebase-auth-better-auth
-version: 1.0.0
 description: >-
   Add Firebase Authentication (Phone SMS OTP, Google Sign-In, Email/Password)
   to a Better Auth app using the better-auth-firebase-auth plugin. Use when
@@ -34,7 +33,7 @@ description: >-
 ## Install
 
 ```bash
-pnpm add better-auth-firebase-auth firebase-admin firebase
+pnpm add better-auth-firebase-auth firebase-admin firebase better-auth
 ```
 
 ---
@@ -153,6 +152,26 @@ await authClient.sendPasswordReset({ email });
 
 ---
 
+## Using with the Firestore adapter
+
+To store Better Auth data in Firestore, combine with `better-auth-firestore`:
+
+```ts
+import { firestoreAdapter } from "better-auth-firestore";
+import { firebaseAuthPlugin } from "better-auth-firebase-auth/server";
+import { getAuth } from "firebase-admin/auth";
+import { getFirestore } from "firebase-admin/firestore";
+
+export const auth = betterAuth({
+  database: firestoreAdapter({ firestore: getFirestore() }),
+  plugins: [firebaseAuthPlugin({ firebaseAdminAuth: getAuth() })],
+});
+```
+
+Remember to create the required Firestore composite index on the verification collection — see [better-auth-firestore](https://github.com/yultyyev/better-auth-firestore).
+
+---
+
 ## Key options
 
 | Option | Default | Notes |
@@ -166,6 +185,20 @@ await authClient.sendPasswordReset({ email });
 
 ---
 
+## Runtime support
+
+| Runtime | Supported |
+|---|---|
+| Node 18+ | ✅ |
+| Next.js on Vercel (Node.js runtime) | ✅ Recommended |
+| Cloud Functions / Cloud Run | ✅ |
+| Vercel Edge Runtime (`runtime = 'edge'`) | ❌ Admin SDK requires Node.js |
+| Cloudflare Workers | ❌ Admin SDK requires Node.js |
+
+**Note:** Vercel deploys work fine — the restriction is only when you explicitly opt into the Edge Runtime (`export const runtime = 'edge'`). The default Node.js serverless runtime on Vercel is fully supported.
+
+---
+
 ## Common mistakes
 
 - **Importing `firebaseAuthPlugin` in client code** — crashes on `firebase-admin`. Always use the `/server` path on the server and `/client` path in the browser.
@@ -173,3 +206,4 @@ await authClient.sendPasswordReset({ email });
 - **Missing reCAPTCHA container** — `signInWithPhoneNumber` requires a `RecaptchaVerifier` with a DOM element id. For invisible reCAPTCHA use `size: "invisible"`.
 - **Firebase Admin not initialized before `getAuth()`** — call `initializeApp()` once before passing `getAuth()` to the plugin.
 - **Using `overrideEmailPasswordFlow: true` without `firebaseConfig`** — throws at startup. This mode requires the Firebase client SDK config.
+- **FIREBASE_PRIVATE_KEY with literal `\n`** — Always call `.replace(/\\n/g, "\n")` on the key before passing to `cert()`.


### PR DESCRIPTION
## Summary

- Move `SKILL.md` back to the repo root, matching the working layout in [better-auth-firestore](https://github.com/yultyyev/better-auth-firestore) so `npx skills add yultyyev/better-auth-firebase-auth` discovers the skill reliably
- Remove the nested `skills/firebase-auth-better-auth/` path and `version` frontmatter added in #25
- Expand skill content with Firestore adapter cross-link, runtime support table, and `FIREBASE_PRIVATE_KEY` gotcha
- Update README AI Assistant Skill section and switch Firestore adapter references to unscoped `better-auth-firestore`

## Test plan

- [ ] `npx skills add yultyyev/better-auth-firebase-auth` finds `firebase-auth-better-auth` from root `SKILL.md`
- [ ] README skill section and Firestore adapter links render correctly