### PR TITLE
feat(server): Better Auth 1.7 support, working package entry points, TypeScript 6/7

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,30 @@
+# Release Process
+
+Releases are automated via **semantic-release** on every push to `main`. The version bump is determined solely by the **git commit messages** that land on `main`.
+
+## What ends up in the release notes
+
+There is no committed `CHANGELOG.md` (the repo does not run `@semantic-release/git`), so the **GitHub Release** is the durable changelog. semantic-release builds it from the **subject line** of every `feat:` / `fix:` / `perf:` commit since the last tag — commit **bodies never render**, and `docs:` / `ci:` / `chore:` / `test:` / `refactor:` commits are hidden. Two consequences:
+
+- Put the **user-facing impact** in the subject (`fix(build): make require("better-auth-firebase-auth") work on Node >= 22.12`), not the implementation (`fix(build): drop the unbuilt CJS entry`). Keep the deeper explanation in the body and the README.
+- Operational steps that do not fit a subject (a data backfill, a column to add) belong in the README; append them to the GitHub Release body after it is published if they matter to upgraders.
+
+## PR title → version bump (squash merge)
+
+With **Squash and merge**, GitHub uses the **PR title** as the squash commit subject whenever the PR has more than one commit. So the PR title controls the release — use squash when the PR is one logical change. When a PR carries several release-worthy commits (a stacked integration branch), prefer **Rebase and merge** so every commit subject gets its own line in the notes; the bump is still the highest type among them.
+
+| Commit / PR title prefix | Result |
+|--------------------------|--------|
+| `feat: …` | **minor** bump |
+| `fix: …` / `fix(scope): …` | **patch** bump |
+| `feat!: …` or commit footer `BREAKING CHANGE:` | **major** bump |
+| `docs:` / `ci:` / `test:` / `chore:` / `chore(deps):` / `refactor:` | **no release** |
+
+Dependency bumps are `chore(deps)` and stay inert: the package ships only `dist/` and declares every runtime dependency as a peer, so a bump cannot change what consumers install. Use `fix(deps):` or `fix(security):` when a change genuinely needs to be published (a peer range, for example).
+
+> With **Merge commit** or **Rebase and merge** the PR title is ignored — individual branch commit messages are used instead.
+
+## Branches
+
+- `main` → stable releases (`2.1.0`, `2.2.0`, …)
+- `next` → pre-releases (`2.2.0-alpha.1`, …)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,3 +50,45 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+  compat:
+    name: Test against better-auth ${{ matrix.better-auth }}
+    runs-on: ubuntu-latest
+    needs: checks
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Oldest supported line (peerDependencies floor), last line before the
+        # 1.7 account-identity change, and the current line.
+        better-auth: ["1.5", "1.6", "1.7"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 11.10.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Swap the dev dependency in place (not committed). The build always
+      # compiles against the lockfile version; this job only checks runtime
+      # behaviour of the version-detection in createOrUpdateUser.
+      - name: Install better-auth ${{ matrix.better-auth }}
+        run: pnpm add --save-dev --workspace-root "better-auth@${{ matrix.better-auth }}"
+
+      - name: Show resolved version
+        run: node -p "'better-auth ' + require('./node_modules/better-auth/package.json').version"
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # The unit tests run against src/, so nothing above this point exercises
+      # what npm actually publishes. Packs the tarball, installs it into a
+      # throwaway consumer, and checks every entry point resolves and types.
+      - name: Verify packed artifact
+        run: ./scripts/verify-pack.sh
+
   compat:
     name: Test against better-auth ${{ matrix.better-auth }}
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,16 +56,16 @@ All authentication methods follow the same core flow:
 2. **Verify token** with Firebase Admin SDK (`adminAuth.verifyIdToken()`)
 3. **Create/update Better Auth user** via `internalAdapter.createUser()` / `internalAdapter.updateUser()`
 4. **Create Better Auth session** via `internalAdapter.createSession()`
-5. **Store account link** via `adapter.createAccount()` or `adapter.upsertAccount()` with `provider: "firebase"`
+5. **Store account link** via `internalAdapter.linkAccount()` / `internalAdapter.updateAccount()` with `providerId: "firebase"`, `accountId: <Firebase UID>`, `issuer: FIREBASE_ACCOUNT_ISSUER`
 
 When adding new providers, follow the `signInWithGoogle` endpoint pattern as a reference implementation.
 
 ### Important Notes
 
-- All Firebase authentication methods use `provider: "firebase"` in account records
-- `providerAccountId` should be the Firebase UID
-- User operations must use `internalAdapter` (not `adapter`) for proper database hooks and secondary storage support
-- Account operations use `adapter` directly
+- All Firebase authentication methods use `providerId: "firebase"` in account records
+- `accountId` is the Firebase UID; `issuer` is `FIREBASE_ACCOUNT_ISSUER` (`"local:oauth:firebase"`)
+- User, account, and session operations all go through `internalAdapter` (not `adapter`) for proper database hooks and secondary storage support
+- Better Auth 1.7 keys accounts by `(issuer, accountId)` and removed `findOAuthUser`; 1.5 – 1.6 key them by `(providerId, accountId)`. `findFirebaseAccountOwner` in `src/firebase-auth-plugin.ts` feature-detects `findAccountOwnerByKey` so one build supports both. CI runs the tests against 1.5, 1.6, and 1.7 — keep that matrix green when touching the lookup
 
 ## Project Files
 
@@ -120,9 +120,9 @@ examples/
 
 ### Account Storage
 
-- All Firebase Auth methods use `provider: "firebase"` in account records
-- `providerAccountId` should be the Firebase UID
-- Use `context.adapter.account.create()` or `context.adapter.account.upsert()` for account records
+- All Firebase Auth methods use `providerId: "firebase"` in account records
+- `accountId` is the Firebase UID; `issuer` is `FIREBASE_ACCOUNT_ISSUER`
+- Use `context.internalAdapter.linkAccount()` / `updateAccount()` for account records
 
 ### Endpoint Creation Pattern
 
@@ -169,7 +169,7 @@ if (!token) {
 
 ### User and Session Creation
 
-- Use `context.adapter` to create/update users
+- Use `context.internalAdapter.createUser()` / `updateUser()` to create/update users (`createUser` takes a provisioning `source` on 1.7; older versions ignore it)
 - Use `context.internalAdapter.createSession()` to create sessions
 - Map Firebase user data (uid, email, name, photoURL) to Better Auth user schema
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,21 @@ pnpm lint:fix
    pnpm lint
    ```
 
-7. Commit your changes with a descriptive message following Conventional Commits format:
+7. If you touched packaging -- `package.json` (`exports`, `main`, `types`),
+   `tsconfig.build.json`, or the files behind an entry point -- verify the
+   published artifact:
+   ```bash
+   pnpm verify:pack
+   ```
+
+   The unit tests import from `src/`, so they cannot catch a broken `exports`
+   map or an unresolvable specifier in `dist/`. This packs the tarball,
+   installs it into a throwaway consumer next to the peer deps, and checks
+   that every entry point resolves from ESM and CJS and still carries its
+   types under both `nodenext` and `bundler` module resolution. CI runs it on
+   every pull request.
+
+8. Commit your changes with a descriptive message following Conventional Commits format:
    ```bash
    # For new features
    feat(firebase-auth): add phone number authentication support
@@ -137,14 +151,14 @@ pnpm lint:fix
    for `fix(deps):` or `fix(security):` when a change genuinely needs to be
    published.
 
-8. Push your branch to your fork
+9. Push your branch to your fork
 
-9. Open a pull request against the **main** branch. In your PR description:
-   - Clearly describe what changes you made and why
-   - Include any relevant context or background
-   - List any breaking changes or deprecations
-   - Reference related issues or discussions
-   - Include examples if adding new features
+10. Open a pull request against the **main** branch. In your PR description:
+    - Clearly describe what changes you made and why
+    - Include any relevant context or background
+    - List any breaking changes or deprecations
+    - Reference related issues or discussions
+    - Include examples if adding new features
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Firebase verifies identity. Better Auth owns the session. No Twilio required for
 
 - **Install:** `pnpm add better-auth-firebase-auth firebase-admin firebase better-auth`
 
+> **Upgrading to Better Auth 1.7 with existing users?** Run the one-time `account.issuer` backfill before your first deploy on 1.7 — see [Upgrading an existing app to Better Auth 1.7](#upgrading-an-existing-app-to-better-auth-17).
+
 ---
 
 ## How it works

--- a/README.md
+++ b/README.md
@@ -335,8 +335,30 @@ Both approaches add phone authentication to a Better Auth app. The right choice 
 
 ## Better Auth Compatibility
 
-- **Better Auth v1.5+:** `createAuthMiddleware` from `better-auth/api` (preferred)
-- **Older releases:** automatically falls back to `better-auth/plugins`
+One build of the plugin supports every Better Auth release since 1.5. The plugin detects the account-lookup API at runtime, and CI runs the test suite against the 1.5, 1.6, and 1.7 lines.
+
+| Better Auth | Status |
+|---|---|
+| 1.7.x | Supported — accounts keyed by `(issuer, accountId)` |
+| 1.5.x – 1.6.x | Supported — accounts keyed by `(providerId, accountId)` |
+| < 1.5 | Not supported |
+
+### Upgrading an existing app to Better Auth 1.7
+
+Better Auth 1.7 adds a required `issuer` column to the `account` table and looks accounts up by `(issuer, accountId)` — there is no fallback to `providerId`. `npx auth migrate` refuses to add a `NOT NULL` column to a populated table, so every existing install needs a one-time backfill. This is part of the [Better Auth 1.7 upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer); the plugin-specific part is the value to use for Firebase rows:
+
+1. Add `issuer` to `account` as a **nullable** column.
+2. Backfill Firebase-linked rows (and any other providers you use, per the upgrade guide):
+
+   ```sql
+   UPDATE account SET issuer = 'local:oauth:firebase' WHERE "providerId" = 'firebase';
+   ```
+
+3. Make `issuer` `NOT NULL` and add the unique `(issuer, accountId)` index (`npx auth migrate` / `npx auth generate` can do this step once no row is empty).
+
+The value is exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server` for use in migration scripts. New rows written on Better Auth 1.7 already carry it.
+
+If the backfill is skipped, sign-in still works: the plugin falls back to matching by email and links a fresh account row — but the old row is left orphaned and, on MySQL, `auth migrate` may have silently filled `issuer` with an empty string (see the upgrade guide's corruption check).
 
 ---
 

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "better-auth": "^1.5.6",
+    "better-auth": "^1.7.1",
     "better-auth-firebase-auth": "file:../..",
     "firebase": "^12.11.0",
     "firebase-admin": "^14.3.0",

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -21,8 +21,8 @@
     "@types/node": "^24",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "eslint": "^10.6.0",
-    "eslint-config-next": "^16.2.1",
-    "typescript": "^6.0.3"
+    "eslint": "^10.9.0",
+    "eslint-config-next": "^16.3.2",
+    "typescript": "^7.0.2"
   }
 }

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -18,7 +18,7 @@
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@types/node": "^24.13.2",
+    "@types/node": "^24",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^10.6.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
-    "better-auth": "^1.6.5",
+    "better-auth": "^1.7.1",
     "better-sqlite3": "^12.9.0",
     "firebase": "^12.12.0",
     "firebase-admin": "^14.3.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "better-auth": "^1.7.1",
-    "better-sqlite3": "^12.9.0",
     "firebase": "^12.12.0",
     "firebase-admin": "^14.3.0",
     "rimraf": "^6.1.3",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "typescript": ">=5.0.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.4.12",
-    "@semantic-release/changelog": "^6.0.3",
+    "@biomejs/biome": "^2.5.10",
+    "@semantic-release/changelog": "^7.0.0",
     "@semantic-release/commit-analyzer": "^13.0.1",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/github": "^12.0.6",
@@ -83,9 +83,9 @@
     "firebase": "^12.12.0",
     "firebase-admin": "^14.3.0",
     "rimraf": "^6.1.3",
-    "semantic-release": "^25.0.3",
-    "typescript": "^6.0.3",
+    "semantic-release": "^25.0.9",
+    "typescript": "^7.0.2",
     "vite": "^8.1.3",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,22 +6,21 @@
   "author": "Slava Yultyyev <yultyyev@gmail.com>",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./client": {
       "types": "./dist/firebase-auth-client-plugin.d.ts",
-      "import": "./dist/firebase-auth-client-plugin.js"
+      "default": "./dist/firebase-auth-client-plugin.js"
     },
     "./server": {
       "types": "./dist/firebase-auth-plugin.d.ts",
-      "import": "./dist/firebase-auth-plugin.js"
+      "default": "./dist/firebase-auth-plugin.js"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "biome check --formatter-enabled=false",
     "lint:fix": "biome check --write",
     "lint:fix:unsafe": "biome check --write --unsafe",
+    "verify:pack": "./scripts/verify-pack.sh",
     "prepublishOnly": "pnpm run build"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "better-auth": ">=1.5.0",
     "firebase": ">=9",
     "firebase-admin": ">=13",
-    "typescript": "^5.0.0"
+    "typescript": ">=5.0.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@grpc/grpc-js': '>=1.14.4'
+  '@types/node': ^24
   '@tootallnate/once': ^3.0.1
   brace-expansion: '>=5.0.9'
   defu: ^6.1.5
@@ -51,7 +52,7 @@ importers:
         version: 14.1.1(semantic-release@25.0.5(typescript@6.0.3))
       better-auth:
         specifier: ^1.7.1
-        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)))
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       firebase:
         specifier: ^12.12.0
         version: 12.16.0
@@ -69,19 +70,19 @@ importers:
         version: 6.0.3
       vite:
         specifier: '>=7.3.5 <8'
-        version: 7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)
+        version: 7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
 
   examples/minimal:
     dependencies:
       better-auth:
         specifier: ^1.7.1
-        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       better-auth-firebase-auth:
         specifier: file:../..
-        version: file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3)
+        version: file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3)
       firebase:
         specifier: ^12.11.0
         version: 12.16.0
@@ -90,7 +91,7 @@ importers:
         version: 14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1)
       next:
         specifier: ^16.3.2
-        version: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
+        version: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
       react:
         specifier: ^19.2.4
         version: 19.2.7
@@ -99,8 +100,8 @@ importers:
         version: 19.2.8(react@19.2.7)
     devDependencies:
       '@types/node':
-        specifier: ^24.13.2
-        version: 24.13.2
+        specifier: ^24
+        version: 24.13.3
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.17
@@ -1472,14 +1473,8 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@24.13.2':
-    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
-
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
-
-  '@types/node@26.1.0':
-    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -4380,9 +4375,6 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici-types@8.3.0:
-    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
-
   undici@7.29.0:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
@@ -4445,7 +4437,7 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
-      '@types/node': ^20.19.0 || >=22.12.0
+      '@types/node': ^24
       jiti: '>=1.21.0'
       less: ^4.0.0
       lightningcss: ^1.21.0
@@ -4487,7 +4479,7 @@ packages:
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@types/node': ^24
       '@vitest/browser-playwright': 4.1.10
       '@vitest/browser-preview': 4.1.10
       '@vitest/browser-webdriverio': 4.1.10
@@ -5979,18 +5971,9 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@24.13.2':
-    dependencies:
-      undici-types: 7.18.2
-
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/node@26.1.0':
-    dependencies:
-      undici-types: 8.3.0
-    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -6191,22 +6174,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)
-    optional: true
-
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -6402,14 +6376,14 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth-firebase-auth@file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3):
+  better-auth-firebase-auth@file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3):
     dependencies:
-      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
+      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       firebase: 12.16.0
       firebase-admin: 14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1)
       typescript: 6.0.3
 
-  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))):
+  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))):
     dependencies:
       '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -6431,40 +6405,10 @@ snapshots:
     optionalDependencies:
       better-sqlite3: 12.11.1
       mongodb: 7.1.0
-      next: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
+      next: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.8(react@19.2.7)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))):
-    dependencies:
-      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      '@noble/ciphers': 2.2.0
-      '@noble/hashes': 2.2.0
-      better-call: 1.4.0(zod@4.4.3)
-      defu: 6.1.7
-      jose: 6.2.9
-      kysely: 0.28.17
-      nanostores: 1.4.0
-      zod: 4.4.3
-    optionalDependencies:
-      better-sqlite3: 12.11.1
-      mongodb: 7.1.0
-      next: 16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.8(react@19.2.7)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -8275,7 +8219,7 @@ snapshots:
 
   nerf-dart@1.0.0: {}
 
-  next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7):
+  next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7):
     dependencies:
       '@next/env': 16.3.2
       '@swc/helpers': 0.5.23
@@ -8295,38 +8239,11 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.3.2
       '@next/swc-win32-x64-msvc': 16.3.2
       '@opentelemetry/api': 1.9.1
-      sharp: 0.35.3(@types/node@24.13.2)
+      sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@babel/core'
       - '@types/node'
       - babel-plugin-macros
-
-  next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7):
-    dependencies:
-      '@next/env': 16.3.2
-      '@swc/helpers': 0.5.23
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001802
-      postcss: 8.5.23
-      react: 19.2.7
-      react-dom: 19.2.8(react@19.2.7)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.7)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.2
-      '@next/swc-darwin-x64': 16.3.2
-      '@next/swc-linux-arm64-gnu': 16.3.2
-      '@next/swc-linux-arm64-musl': 16.3.2
-      '@next/swc-linux-x64-gnu': 16.3.2
-      '@next/swc-linux-x64-musl': 16.3.2
-      '@next/swc-win32-arm64-msvc': 16.3.2
-      '@next/swc-win32-x64-msvc': 16.3.2
-      '@opentelemetry/api': 1.9.1
-      sharp: 0.35.3(@types/node@26.1.0)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/node'
-      - babel-plugin-macros
-    optional: true
 
   node-abi@3.94.0:
     dependencies:
@@ -8910,7 +8827,7 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  sharp@0.35.3(@types/node@24.13.2):
+  sharp@0.35.3(@types/node@24.13.3):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
@@ -8941,41 +8858,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.35.3
       '@img/sharp-win32-ia32': 0.35.3
       '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 24.13.2
-    optional: true
-
-  sharp@0.35.3(@types/node@26.1.0):
-    dependencies:
-      '@img/colour': 1.1.0
-      detect-libc: 2.1.2
-      semver: 7.8.5
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 26.1.0
+      '@types/node': 24.13.3
     optional: true
 
   shebang-command@2.0.0:
@@ -9408,9 +9291,6 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@8.3.0:
-    optional: true
-
   undici@7.29.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
@@ -9478,7 +9358,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0):
+  vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -9487,28 +9367,14 @@ snapshots:
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 24.13.2
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-    optional: true
-
-  vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0):
-    dependencies:
-      esbuild: 0.28.1
-      fdir: 6.5.0(picomatch@4.0.5)
-      picomatch: 4.0.5
-      postcss: 8.5.26
-      rollup: 4.62.2
-      tinyglobby: 0.2.17
-    optionalDependencies:
-      '@types/node': 26.1.0
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -9525,40 +9391,11 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.2
-    transitivePeerDependencies:
-      - msw
-    optional: true
-
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.3.0
-      expect-type: 1.4.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.5
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 26.1.0
+      '@types/node': 24.13.3
     transitivePeerDependencies:
       - msw
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       better-auth:
         specifier: ^1.7.1
         version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)))
-      better-sqlite3:
-        specifier: ^12.9.0
-        version: 12.11.1
       firebase:
         specifier: ^12.12.0
         version: 12.16.0
@@ -6485,18 +6482,21 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   bottleneck@2.19.5: {}
 
@@ -6525,6 +6525,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6564,7 +6565,8 @@ snapshots:
 
   char-regex@1.0.2: {}
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   clean-stack@2.2.0: {}
 
@@ -6715,6 +6717,7 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-extend@0.6.0: {}
 
@@ -6737,7 +6740,8 @@ snapshots:
   delayed-stream@1.0.0:
     optional: true
 
-  detect-libc@2.1.2: {}
+  detect-libc@2.1.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -6789,6 +6793,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   env-ci@11.2.0:
     dependencies:
@@ -7190,7 +7195,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.4.0: {}
 
@@ -7255,7 +7261,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
+  file-uri-to-path@1.0.0:
+    optional: true
 
   fill-range@7.1.1:
     dependencies:
@@ -7358,7 +7365,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.4:
     dependencies:
@@ -7501,7 +7509,8 @@ snapshots:
       through2: 2.0.5
       traverse: 0.6.8
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -7730,7 +7739,8 @@ snapshots:
 
   idb@7.1.1: {}
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -8206,7 +8216,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -8225,7 +8236,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mongodb-connection-string-url@7.0.1:
     dependencies:
@@ -8252,7 +8264,8 @@ snapshots:
 
   nanostores@1.4.0: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   napi-postinstall@0.3.4: {}
 
@@ -8318,6 +8331,7 @@ snapshots:
   node-abi@3.94.0:
     dependencies:
       semver: 7.8.5
+    optional: true
 
   node-domexception@1.0.0: {}
 
@@ -8423,6 +8437,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   onetime@6.0.0:
     dependencies:
@@ -8580,6 +8595,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -8622,6 +8638,7 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -8688,6 +8705,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -9004,13 +9022,15 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   skin-tone@2.0.0:
     dependencies:
@@ -9146,6 +9166,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -9207,6 +9228,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -9215,6 +9237,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   teeny-request@10.1.4:
     dependencies:
@@ -9305,6 +9328,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   tunnel@0.0.6: {}
 
@@ -9643,7 +9667,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   xml-naming@0.3.0:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1882,7 +1882,7 @@ packages:
       better-auth: '>=1.5.0'
       firebase: '>=9'
       firebase-admin: '>=13'
-      typescript: ^5.0.0
+      typescript: '>=5.0.0'
 
   better-auth@1.7.1:
     resolution: {integrity: sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,8 +50,8 @@ importers:
         specifier: ^14.1.0
         version: 14.1.1(semantic-release@25.0.5(typescript@6.0.3))
       better-auth:
-        specifier: ^1.6.5
-        version: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)))
+        specifier: ^1.7.1
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)))
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.11.1
@@ -80,11 +80,11 @@ importers:
   examples/minimal:
     dependencies:
       better-auth:
-        specifier: ^1.5.6
-        version: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
+        specifier: ^1.7.1
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
       better-auth-firebase-auth:
         specifier: file:../..
-        version: file:(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3)
+        version: file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3)
       firebase:
         specifier: ^12.11.0
         version: 12.16.0
@@ -209,14 +209,14 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@better-auth/core@1.6.23':
-    resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
+  '@better-auth/core@1.7.1':
+    resolution: {integrity: sha512-eZ9lqcnVLMZ3QtUByRo4VZqkB1ESyRddd9NfWjBdDPgh+jcwLScoIUAqhtHLR8zaSUJZah8OLGlkzObyPdUH7A==}
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@cloudflare/workers-types': '>=4'
       '@opentelemetry/api': ^1.9.0
-      better-call: 1.3.7
+      better-call: 1.4.0
       jose: ^6.1.0
       kysely: ^0.28.14
       nanostores: ^1.0.1
@@ -226,46 +226,46 @@ packages:
       '@opentelemetry/api':
         optional: true
 
-  '@better-auth/drizzle-adapter@1.6.23':
-    resolution: {integrity: sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==}
+  '@better-auth/drizzle-adapter@1.7.1':
+    resolution: {integrity: sha512-qlqNyg5V9bXHSP68/vtlsiZayhR4hgvEGiS/E3SIj8bCpWWFGmyQkxJbQCqpBmC7vT30wE/kNtJMHIgnV3rkiw==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
-      drizzle-orm: ^0.45.2
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
     peerDependenciesMeta:
       drizzle-orm:
         optional: true
 
-  '@better-auth/kysely-adapter@1.6.23':
-    resolution: {integrity: sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==}
+  '@better-auth/kysely-adapter@1.7.1':
+    resolution: {integrity: sha512-yWCpE1cZpMUj37nD6JFDK+GDR8zS37L5WI73il3qbU9TXtWsxUQKc/5c3IHsHizWQsmcQI8uv2pAFKxsRDa+AQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       kysely: ^0.28.14
     peerDependenciesMeta:
       kysely:
         optional: true
 
-  '@better-auth/memory-adapter@1.6.23':
-    resolution: {integrity: sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==}
+  '@better-auth/memory-adapter@1.7.1':
+    resolution: {integrity: sha512-6NX1yv88DeqdoG7owYFqKwlrDGaIPhsC52JUGrUgeGVKyOq8a/6hHlHsqG1C2FwT23SHQiKVYCEAG9N6aH5OvQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23':
-    resolution: {integrity: sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==}
+  '@better-auth/mongo-adapter@1.7.1':
+    resolution: {integrity: sha512-9ILTcNqhG37QK//qR4UhYLyKzNqq6w6zVTf5KX6xkiTjNcV7Oh1yS31lkIJEVTqRNcy9AoV6FZMW6Bbsm8IMDA==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       mongodb: ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       mongodb:
         optional: true
 
-  '@better-auth/prisma-adapter@1.6.23':
-    resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
+  '@better-auth/prisma-adapter@1.7.1':
+    resolution: {integrity: sha512-ZiUcafQ85InAofcUjyGgCPjKLfQjXr9SvDmMjuFUW8oEbreA6C6GaFAEA77VuV2doZUQlzvQQ4gCoTmS28W92A==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -275,15 +275,18 @@ packages:
       prisma:
         optional: true
 
-  '@better-auth/telemetry@1.6.23':
-    resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
+  '@better-auth/telemetry@1.7.1':
+    resolution: {integrity: sha512-kLKjMfFlTbyt49DGeI9okHAsn0MtBZcMoQYKaEdgR0H3BHzqqyzePcQz/hxAmRgjB4p/6inise3zJwhX0sgXrQ==}
     peerDependencies:
-      '@better-auth/core': ^1.6.23
+      '@better-auth/core': ^1.7.1
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-auth/utils@0.5.0':
+    resolution: {integrity: sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA==}
 
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
@@ -1881,8 +1884,8 @@ packages:
       firebase-admin: '>=13'
       typescript: ^5.0.0
 
-  better-auth@1.6.23:
-    resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
+  better-auth@1.7.1:
+    resolution: {integrity: sha512-g8WlTQijxXWJjPVZfFu1+EJg9cwwHrKDmIkcYMzx8CzYA+tDxl6NI7qQbKkbgw5UtHILsT5VH+RMzFzwnVJqAg==}
     peerDependencies:
       '@lynx-js/react': '*'
       '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1890,8 +1893,8 @@ packages:
       '@tanstack/react-start': ^1.0.0
       '@tanstack/solid-start': ^1.0.0
       better-sqlite3: ^12.0.0
-      drizzle-kit: '>=0.31.4'
-      drizzle-orm: ^0.45.2
+      drizzle-kit: '>=0.31.4 || >=1.0.0-beta.1'
+      drizzle-orm: ^0.45.2 || >=1.0.0-rc.1 <2.0.0
       mongodb: ^6.0.0 || ^7.0.0
       mysql2: ^3.0.0
       next: ^16.3.2
@@ -1943,8 +1946,8 @@ packages:
       vue:
         optional: true
 
-  better-call@1.3.7:
-    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+  better-call@1.4.0:
+    resolution: {integrity: sha512-bBKOT4vv1kZLDgxVePdilk/Jwkn+dtRRsmi3DzHcDP+WnswyVl6dR59l2HEeP/0cB+bDoopASAesWDPIdd/zZA==}
     peerDependencies:
       zod: ^4.0.0
     peerDependenciesMeta:
@@ -3060,9 +3063,6 @@ packages:
     resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
     engines: {node: '>= 0.6.0'}
 
-  jose@6.2.3:
-    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
-
   jose@6.2.9:
     resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
 
@@ -3955,8 +3955,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rou3@0.7.12:
-    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
+  rou3@0.9.2:
+    resolution: {integrity: sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -4786,56 +4786,60 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)':
+  '@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@opentelemetry/semantic-conventions': 1.43.0
       '@standard-schema/spec': 1.1.0
-      better-call: 1.3.7(zod@4.4.3)
-      jose: 6.2.3
+      better-call: 1.4.0(zod@4.4.3)
+      jose: 6.2.9
       kysely: 0.28.17
       nanostores: 1.4.0
       zod: 4.4.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/drizzle-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
+  '@better-auth/kysely-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.28.17
 
-  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)':
+  '@better-auth/mongo-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 7.1.0
 
-  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
   '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-auth/utils@0.5.0':
     dependencies:
       '@noble/hashes': 2.2.0
 
@@ -6401,29 +6405,29 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth-firebase-auth@file:(better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3):
+  better-auth-firebase-auth@file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3):
     dependencies:
-      better-auth: 1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
+      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0)))
       firebase: 12.16.0
       firebase-admin: 14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1)
       typescript: 6.0.3
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))):
+  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(vite@7.3.6(@types/node@24.13.2)(lightningcss@1.32.0))):
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@4.4.3)
+      better-call: 1.4.0(zod@4.4.3)
       defu: 6.1.7
-      jose: 6.2.3
+      jose: 6.2.9
       kysely: 0.28.17
       nanostores: 1.4.0
       zod: 4.4.3
@@ -6438,22 +6442,22 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-auth@1.6.23(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))):
+  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0))):
     dependencies:
-      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0)
-      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
-      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)
-      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.28.17)
+      '@better-auth/memory-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(mongodb@7.1.0)
+      '@better-auth/prisma-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
-      better-call: 1.3.7(zod@4.4.3)
+      better-call: 1.4.0(zod@4.4.3)
       defu: 6.1.7
-      jose: 6.2.3
+      jose: 6.2.9
       kysely: 0.28.17
       nanostores: 1.4.0
       zod: 4.4.3
@@ -6468,11 +6472,11 @@ snapshots:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
 
-  better-call@1.3.7(zod@4.4.3):
+  better-call@1.4.0(zod@4.4.3):
     dependencies:
-      '@better-auth/utils': 0.4.2
+      '@better-auth/utils': 0.5.0
       '@better-fetch/fetch': 1.3.1
-      rou3: 0.7.12
+      rou3: 0.9.2
       set-cookie-parser: 3.1.2
     optionalDependencies:
       zod: 4.4.3
@@ -7932,8 +7936,6 @@ snapshots:
 
   java-properties@1.0.2: {}
 
-  jose@6.2.3: {}
-
   jose@6.2.9: {}
 
   js-tokens@4.0.0: {}
@@ -8792,7 +8794,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
-  rou3@0.7.12: {}
+  rou3@0.9.2: {}
 
   run-parallel@1.2.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,29 +30,29 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.12
-        version: 2.5.2
+        specifier: ^2.5.10
+        version: 2.5.10
       '@semantic-release/changelog':
-        specifier: ^6.0.3
-        version: 6.0.3(semantic-release@25.0.5(typescript@6.0.3))
+        specifier: ^7.0.0
+        version: 7.0.0(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/commit-analyzer':
         specifier: ^13.0.1
-        version: 13.0.1(semantic-release@25.0.5(typescript@6.0.3))
+        version: 13.0.1(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/exec':
         specifier: ^7.1.0
-        version: 7.1.0(semantic-release@25.0.5(typescript@6.0.3))
+        version: 7.1.0(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/github':
         specifier: ^12.0.6
-        version: 12.0.9(semantic-release@25.0.5(typescript@6.0.3))
+        version: 12.0.9(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/npm':
         specifier: ^13.1.5
-        version: 13.1.5(semantic-release@25.0.5(typescript@6.0.3))
+        version: 13.1.5(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/release-notes-generator':
         specifier: ^14.1.0
-        version: 14.1.1(semantic-release@25.0.5(typescript@6.0.3))
+        version: 14.1.1(semantic-release@25.0.9(typescript@7.0.2))
       better-auth:
         specifier: ^1.7.1
-        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       firebase:
         specifier: ^12.12.0
         version: 12.16.0
@@ -63,26 +63,26 @@ importers:
         specifier: ^6.1.3
         version: 6.1.3
       semantic-release:
-        specifier: ^25.0.3
-        version: 25.0.5(typescript@6.0.3)
+        specifier: ^25.0.9
+        version: 25.0.9(typescript@7.0.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: '>=7.3.5 <8'
         version: 7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)
       vitest:
-        specifier: ^4.1.4
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
+        specifier: ^4.1.11
+        version: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
 
   examples/minimal:
     dependencies:
       better-auth:
         specifier: ^1.7.1
-        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
+        version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       better-auth-firebase-auth:
         specifier: file:../..
-        version: file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3)
+        version: file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@7.0.2)
       firebase:
         specifier: ^12.11.0
         version: 12.16.0
@@ -109,14 +109,14 @@ importers:
         specifier: ^19.2.3
         version: 19.2.4(@types/react@19.2.17)
       eslint:
-        specifier: ^10.6.0
-        version: 10.6.0
+        specifier: ^10.9.0
+        version: 10.9.0
       eslint-config-next:
-        specifier: ^16.2.1
-        version: 16.2.10(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
+        specifier: ^16.3.2
+        version: 16.3.2(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0)(typescript@7.0.2)
       typescript:
-        specifier: ^6.0.3
-        version: 6.0.3
+        specifier: ^7.0.2
+        version: 7.0.2
 
 packages:
 
@@ -289,59 +289,59 @@ packages:
   '@better-fetch/fetch@1.3.1':
     resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
-  '@biomejs/biome@2.5.2':
-    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
+  '@biomejs/biome@2.5.10':
+    resolution: {integrity: sha512-WRKXARA3kTuiV5sxqTpobJ/I0MVd4vk3pOL6wnp5az4LntFIhWTj1RWZq3DI9PCEN3lXcqy7p5aqUHzvq8AXyQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
-    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
+  '@biomejs/cli-darwin-arm64@2.5.10':
+    resolution: {integrity: sha512-ItCrxKK6SXVT6flYs0qIuBd4AA3TTTl4d66Re6YI2FuGZnN85NmuYNzkiTJUyYw8qBLv69L5zTUB6uyWd++h3Q==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.2':
-    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
+  '@biomejs/cli-darwin-x64@2.5.10':
+    resolution: {integrity: sha512-yLsPU9pAmtChXDu8vhKAzErqe+LeeYuwuUB2FZMkRitsmdodxsYRa9KHrFispsUHzzOu+9HB3nP/TQxyia+Sjw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
-    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.10':
+    resolution: {integrity: sha512-t1QAKZwQJRB4dvgJSgFiQ4BNfNPChg69BNonz854qLVxnjT3UvDzQg9mbkTJRu35ZqU0Rw10A73J8Urgbg2RPw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.2':
-    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
+  '@biomejs/cli-linux-arm64@2.5.10':
+    resolution: {integrity: sha512-VG8uQW/86a1roLaIFvtIbEigxIdzdJ190oGyg1tV7VYeQtOS+x10sflk7WbuXgw91EtZX5DlIIIej1YqkNLlcg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
-    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
+  '@biomejs/cli-linux-x64-musl@2.5.10':
+    resolution: {integrity: sha512-pgDDqp9JybHm2I0KRgzN6i4+lt8xu4iqxUwLzglUMmOmyRTU1AYBGKzh9sNMOtIjah7xoWvKHlLVetvyifzoiQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.2':
-    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
+  '@biomejs/cli-linux-x64@2.5.10':
+    resolution: {integrity: sha512-4O6T0eq2heoHZN0a9UX+rWQoxXEBaKf+lRi2hbsGlHneUz9BWXM76nEWMK7Eeq8gzMxR1khQB6BFpAASpeXqGg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.2':
-    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
+  '@biomejs/cli-win32-arm64@2.5.10':
+    resolution: {integrity: sha512-pxAbxduPO4xq/Cvgaa2lOrs9BB0hEXmmDqfMNP4ZOffGOkUrD1/QGw9UAMpFQpX2P8MqTIIRuQKcmetum4Oa6A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.2':
-    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
+  '@biomejs/cli-win32-x64@2.5.10':
+    resolution: {integrity: sha512-M+2dgBsl3lXRiTfgPVc2p3anS4Tocojke4rzFLScZ2Y/wmF+36dRb1iHCLiyGqOzQGyTplZH1HnEYviiAqi3nA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -532,8 +532,8 @@ packages:
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@eslint/config-helpers@0.6.0':
-    resolution: {integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==}
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   '@eslint/core@1.2.1':
@@ -1052,8 +1052,8 @@ packages:
   '@next/env@16.3.2':
     resolution: {integrity: sha512-8k4YoG8cM7LWlkfzGNYCRBbFNlernLiMw4s0btVl+CmmWqn3VpYypA72/5Feb1UWdxe6tHqr5KHP4p4Y4m9luA==}
 
-  '@next/eslint-plugin-next@16.2.10':
-    resolution: {integrity: sha512-Gs8D2m21VnJeFo9qvYIIqJH94frWerWYu41BprU1pLtRVF7PCQNLiFZZ3fG+iPuj3K83Cwv/rt+msLOy8Qgu3Q==}
+  '@next/eslint-plugin-next@16.3.2':
+    resolution: {integrity: sha512-z+HW1cZgt8QhByw8p2EbxF94AImgsKIYUbtSkA7Zld2T9yrKAlys4jNOcAOCtv6csX2CoA/5qCVyesL5pHmJ0A==}
 
   '@next/swc-darwin-arm64@16.3.2':
     resolution: {integrity: sha512-ib5Llm93YCKoKWDh6ZaHq6QWTuOZ2bRkSnUwMmX8dsRIOkBNL1vVlSiUKSfixPL9SSh9pvukzqajk/klkn5vqg==}
@@ -1377,21 +1377,17 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@semantic-release/changelog@6.0.3':
-    resolution: {integrity: sha512-dZuR5qByyfe3Y03TpmCvAxCyTnp7r5XwtHRf/8vD9EAn4ZWbavUX8adMtXYzE86EVh0gyLA7lm5yW4IV30XUag==}
-    engines: {node: '>=14.17'}
+  '@semantic-release/changelog@7.0.0':
+    resolution: {integrity: sha512-TNPyag5db24o7jWjre7UwKB4EcL8oJxbRhnDQ7hmZRAYqzreAc6PgdxQuU3pppp5xQinYtiumL0iG8SSKvnlzg==}
+    engines: {node: ^22.22.2 || >=24.15}
     peerDependencies:
-      semantic-release: '>=18.0.0'
+      semantic-release: '>=20.1.0'
 
   '@semantic-release/commit-analyzer@13.0.1':
     resolution: {integrity: sha512-wdnBPHKkr9HhNhXOhZD5a2LNl91+hs8CC2vsAVYxtZH3y0dV3wKn+uZSN61rdJQZ8EGxzWB3inWocBHV9+u/CQ==}
     engines: {node: '>=20.8.1'}
     peerDependencies:
       semantic-release: '>=20.1.0'
-
-  '@semantic-release/error@3.0.0':
-    resolution: {integrity: sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==}
-    engines: {node: '>=14.17'}
 
   '@semantic-release/error@4.0.0':
     resolution: {integrity: sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==}
@@ -1558,6 +1554,126 @@ packages:
     resolution: {integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     resolution: {integrity: sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==}
     cpu: [arm]
@@ -1678,11 +1794,11 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
     peerDependencies:
       msw: ^2.4.9
       vite: '>=7.3.5 <8'
@@ -1692,20 +1808,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.10':
-    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
-  '@vitest/runner@4.1.10':
-    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
 
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
-  '@vitest/utils@4.1.10':
-    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -2324,8 +2440,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-next@16.2.10:
-    resolution: {integrity: sha512-HSybLOY0QKf39i4FWUqPN0xWiNDi6A6UqJmZtgDkS3zMqjXTqULvj/sueXx3cdCG0mVG+qH6k5/qdegklH1d1w==}
+  eslint-config-next@16.3.2:
+    resolution: {integrity: sha512-gTABOJmyc6pEgSX1Z1VOjBxkSmo5Hkdj+ePclDf8HLGTsnVWzgtDdrOeQrAnUkf0JNJJhwPuXrsIwmFZRKJLoQ==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -2410,8 +2526,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.6.0:
-    resolution: {integrity: sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==}
+  eslint@10.9.0:
+    resolution: {integrity: sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -3270,9 +3386,6 @@ packages:
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
 
-  lodash@4.18.1:
-    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -3974,8 +4087,8 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
-  semantic-release@25.0.5:
-    resolution: {integrity: sha512-mn61SUJwtM8ThrWn2WmgLVpwVJeG/hPSupua1psdMoufmwRIPyvRLkRkL0JDXkP67OntlLWUYnBnfVc8EDO3/g==}
+  semantic-release@25.0.9:
+    resolution: {integrity: sha512-bxve7csK0/Txr++CkfrmV+X1r4jqiSOw2WsSad9E2S68R+ZfLBwDn8IceM8WfiOmKQIHgsQc1cNA8Dzg7U75pg==}
     engines: {node: ^22.14.0 || >= 24.10.0}
     hasBin: true
 
@@ -4358,9 +4471,9 @@ packages:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uglify-js@3.19.3:
@@ -4472,20 +4585,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^24
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
       happy-dom: '*'
       jsdom: '*'
       vite: '>=7.3.5 <8'
@@ -4834,39 +4947,39 @@ snapshots:
 
   '@better-fetch/fetch@1.3.1': {}
 
-  '@biomejs/biome@2.5.2':
+  '@biomejs/biome@2.5.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.2
-      '@biomejs/cli-darwin-x64': 2.5.2
-      '@biomejs/cli-linux-arm64': 2.5.2
-      '@biomejs/cli-linux-arm64-musl': 2.5.2
-      '@biomejs/cli-linux-x64': 2.5.2
-      '@biomejs/cli-linux-x64-musl': 2.5.2
-      '@biomejs/cli-win32-arm64': 2.5.2
-      '@biomejs/cli-win32-x64': 2.5.2
+      '@biomejs/cli-darwin-arm64': 2.5.10
+      '@biomejs/cli-darwin-x64': 2.5.10
+      '@biomejs/cli-linux-arm64': 2.5.10
+      '@biomejs/cli-linux-arm64-musl': 2.5.10
+      '@biomejs/cli-linux-x64': 2.5.10
+      '@biomejs/cli-linux-x64-musl': 2.5.10
+      '@biomejs/cli-win32-arm64': 2.5.10
+      '@biomejs/cli-win32-x64': 2.5.10
 
-  '@biomejs/cli-darwin-arm64@2.5.2':
+  '@biomejs/cli-darwin-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.2':
+  '@biomejs/cli-darwin-x64@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.2':
+  '@biomejs/cli-linux-arm64-musl@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.2':
+  '@biomejs/cli-linux-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.2':
+  '@biomejs/cli-linux-x64-musl@2.5.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.2':
+  '@biomejs/cli-linux-x64@2.5.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.2':
+  '@biomejs/cli-win32-arm64@2.5.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.2':
+  '@biomejs/cli-win32-x64@2.5.10':
     optional: true
 
   '@colors/colors@1.5.0':
@@ -4971,9 +5084,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.6.0)':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.9.0)':
     dependencies:
-      eslint: 10.6.0
+      eslint: 10.9.0
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -4986,7 +5099,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.6.0':
+  '@eslint/config-helpers@0.7.0':
     dependencies:
       '@eslint/core': 1.2.1
 
@@ -5603,9 +5716,12 @@ snapshots:
 
   '@next/env@16.3.2': {}
 
-  '@next/eslint-plugin-next@16.2.10':
+  '@next/eslint-plugin-next@16.3.2(eslint@10.9.0)':
     dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.9.0)
       fast-glob: 3.3.1
+    transitivePeerDependencies:
+      - eslint
 
   '@next/swc-darwin-arm64@16.3.2':
     optional: true
@@ -5831,15 +5947,14 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@semantic-release/changelog@6.0.3(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/changelog@7.0.0(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
-      '@semantic-release/error': 3.0.0
-      aggregate-error: 3.1.0
-      fs-extra: 11.3.4
-      lodash: 4.18.1
-      semantic-release: 25.0.5(typescript@6.0.3)
+      '@semantic-release/error': 4.0.0
+      aggregate-error: 5.0.0
+      lodash-es: 4.18.1
+      semantic-release: 25.0.9(typescript@7.0.2)
 
-  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/commit-analyzer@13.0.1(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -5849,15 +5964,13 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       micromatch: 4.0.8
-      semantic-release: 25.0.5(typescript@6.0.3)
+      semantic-release: 25.0.9(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/error@3.0.0': {}
-
   '@semantic-release/error@4.0.0': {}
 
-  '@semantic-release/exec@7.1.0(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/exec@7.1.0(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
       '@semantic-release/error': 4.0.0
       aggregate-error: 3.1.0
@@ -5865,11 +5978,11 @@ snapshots:
       execa: 9.6.1
       lodash-es: 4.18.1
       parse-json: 8.3.0
-      semantic-release: 25.0.5(typescript@6.0.3)
+      semantic-release: 25.0.9(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@12.0.9(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/github@12.0.9(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
       '@octokit/core': 7.0.6
       '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
@@ -5885,7 +5998,7 @@ snapshots:
       lodash-es: 4.18.1
       mime: 4.1.0
       p-filter: 4.1.0
-      semantic-release: 25.0.5(typescript@6.0.3)
+      semantic-release: 25.0.9(typescript@7.0.2)
       tinyglobby: 0.2.17
       undici: 7.29.0
       url-join: 5.0.0
@@ -5893,7 +6006,7 @@ snapshots:
       - kerberos
       - supports-color
 
-  '@semantic-release/npm@13.1.5(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/npm@13.1.5(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
       '@actions/core': 3.0.0
       '@semantic-release/error': 4.0.0
@@ -5908,11 +6021,11 @@ snapshots:
       rc: 1.2.8
       read-pkg: 10.1.0
       registry-auth-token: 5.1.1
-      semantic-release: 25.0.5(typescript@6.0.3)
+      semantic-release: 25.0.9(typescript@7.0.2)
       semver: 7.7.4
       tempy: 3.2.0
 
-  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.5(typescript@6.0.3))':
+  '@semantic-release/release-notes-generator@14.1.1(semantic-release@25.0.9(typescript@7.0.2))':
     dependencies:
       conventional-changelog-angular: 8.3.1
       conventional-changelog-writer: 8.4.0
@@ -5922,7 +6035,7 @@ snapshots:
       import-from-esm: 2.0.0
       lodash-es: 4.18.1
       read-package-up: 11.0.0
-      semantic-release: 25.0.5(typescript@6.0.3)
+      semantic-release: 25.0.9(typescript@7.0.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -6004,40 +6117,40 @@ snapshots:
       '@types/webidl-conversions': 7.0.3
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0)(typescript@7.0.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 10.6.0
+      eslint: 10.9.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
       '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3
-      eslint: 10.6.0
-      typescript: 6.0.3
+      eslint: 10.9.0
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.63.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.63.0
       debug: 4.4.3
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6046,47 +6159,47 @@ snapshots:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
 
-  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.63.0(typescript@7.0.2)':
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@10.9.0)(typescript@7.0.2)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
       debug: 4.4.3
-      eslint: 10.6.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      eslint: 10.9.0
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.63.0': {}
 
-  '@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.63.0(typescript@7.0.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@6.0.3)
+      '@typescript-eslint/project-service': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/tsconfig-utils': 8.63.0(typescript@7.0.2)
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.8.5
       tinyglobby: 0.2.17
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
+      ts-api-utils: 2.5.0(typescript@7.0.2)
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.6.0)(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@10.9.0)(typescript@7.0.2)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.9.0)
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      eslint: 10.6.0
-      typescript: 6.0.3
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
+      eslint: 10.9.0
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6094,6 +6207,66 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.63.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@unrs/resolver-binding-android-arm-eabi@1.12.2':
     optional: true
@@ -6165,44 +6338,44 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitest/expect@4.1.10':
+  '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.11(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))':
     dependencies:
-      '@vitest/spy': 4.1.10
+      '@vitest/spy': 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)
 
-  '@vitest/pretty-format@4.1.10':
+  '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.10':
+  '@vitest/runner@4.1.11':
     dependencies:
-      '@vitest/utils': 4.1.10
+      '@vitest/utils': 4.1.11
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.10':
+  '@vitest/snapshot@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.10': {}
+  '@vitest/spy@4.1.11': {}
 
-  '@vitest/utils@4.1.10':
+  '@vitest/utils@4.1.11':
     dependencies:
-      '@vitest/pretty-format': 4.1.10
+      '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -6376,14 +6549,14 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth-firebase-auth@file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@6.0.3):
+  better-auth-firebase-auth@file:(better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))))(firebase-admin@14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1))(firebase@12.16.0)(typescript@7.0.2):
     dependencies:
-      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
+      better-auth: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
       firebase: 12.16.0
       firebase-admin: 14.3.0(@firebase/app-compat@0.5.15)(@firebase/app@0.15.1)
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))):
+  better-auth@1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))):
     dependencies:
       '@better-auth/core': 1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0)
       '@better-auth/drizzle-adapter': 1.7.1(@better-auth/core@1.7.1(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.4.0(zod@4.4.3))(jose@6.2.9)(kysely@0.28.17)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
@@ -6408,7 +6581,7 @@ snapshots:
       next: 16.3.2(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.8(react@19.2.7)
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
+      vitest: 4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - '@opentelemetry/api'
@@ -6607,14 +6780,14 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  cosmiconfig@9.0.2(typescript@6.0.3):
+  cosmiconfig@9.0.2(typescript@7.0.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
       js-yaml: 5.3.0
       parse-json: 5.2.0
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -6906,20 +7079,20 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.2.10(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3):
+  eslint-config-next@16.3.2(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0)(typescript@7.0.2):
     dependencies:
-      '@next/eslint-plugin-next': 16.2.10
-      eslint: 10.6.0
+      '@next/eslint-plugin-next': 16.3.2(eslint@10.9.0)
+      eslint: 10.9.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint@10.6.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.6.0)
-      eslint-plugin-react: 7.37.5(eslint@10.6.0)
-      eslint-plugin-react-hooks: 7.1.1(eslint@10.6.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0))(eslint@10.9.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.0)
+      eslint-plugin-jsx-a11y: 6.10.2(eslint@10.9.0)
+      eslint-plugin-react: 7.37.5(eslint@10.9.0)
+      eslint-plugin-react-hooks: 7.1.1(eslint@10.9.0)
       globals: 16.4.0
-      typescript-eslint: 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      typescript-eslint: 8.63.0(eslint@10.9.0)(typescript@7.0.2)
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-webpack
@@ -6934,33 +7107,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint@10.6.0):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0))(eslint@10.9.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
-      eslint: 10.6.0
+      eslint: 10.9.0
       get-tsconfig: 4.14.0
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint@10.6.0))(eslint@10.6.0):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0))(eslint@10.9.0))(eslint@10.9.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0
+      '@typescript-eslint/parser': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
+      eslint: 10.9.0
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint@10.6.0)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0))(eslint@10.9.0)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@10.6.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint-import-resolver-typescript@3.10.1)(eslint@10.9.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6969,9 +7142,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 10.6.0
+      eslint: 10.9.0
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0))(eslint@10.6.0))(eslint@10.6.0)
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0))(eslint@10.9.0))(eslint@10.9.0)
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -6983,13 +7156,13 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@10.6.0):
+  eslint-plugin-jsx-a11y@6.10.2(eslint@10.9.0):
     dependencies:
       aria-query: 5.3.2
       array-includes: 3.1.9
@@ -6999,7 +7172,7 @@ snapshots:
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
-      eslint: 10.6.0
+      eslint: 10.9.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -7008,18 +7181,18 @@ snapshots:
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.6.0):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.9.0):
     dependencies:
       '@babel/core': 7.29.7
       '@babel/parser': 7.29.7
-      eslint: 10.6.0
+      eslint: 10.9.0
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.5(eslint@10.6.0):
+  eslint-plugin-react@7.37.5(eslint@10.9.0):
     dependencies:
       array-includes: 3.1.9
       array.prototype.findlast: 1.2.5
@@ -7027,7 +7200,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.3.3
-      eslint: 10.6.0
+      eslint: 10.9.0
       estraverse: 5.3.0
       hasown: 2.0.4
       jsx-ast-utils: 3.3.5
@@ -7052,12 +7225,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.6.0:
+  eslint@10.9.0:
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.6.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.9.0)
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
+      '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@humanfs/node': 0.16.8
@@ -8083,8 +8256,6 @@ snapshots:
 
   lodash.uniqby@4.7.0: {}
 
-  lodash@4.18.1: {}
-
   long@5.3.2: {}
 
   loose-envify@1.4.0:
@@ -8760,15 +8931,15 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  semantic-release@25.0.5(typescript@6.0.3):
+  semantic-release@25.0.9(typescript@7.0.2):
     dependencies:
-      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.5(typescript@6.0.3))
+      '@semantic-release/commit-analyzer': 13.0.1(semantic-release@25.0.9(typescript@7.0.2))
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 12.0.9(semantic-release@25.0.5(typescript@6.0.3))
-      '@semantic-release/npm': 13.1.5(semantic-release@25.0.5(typescript@6.0.3))
-      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.5(typescript@6.0.3))
+      '@semantic-release/github': 12.0.9(semantic-release@25.0.9(typescript@7.0.2))
+      '@semantic-release/npm': 13.1.5(semantic-release@25.0.9(typescript@7.0.2))
+      '@semantic-release/release-notes-generator': 14.1.1(semantic-release@25.0.9(typescript@7.0.2))
       aggregate-error: 5.0.0
-      cosmiconfig: 9.0.2(typescript@6.0.3)
+      cosmiconfig: 9.0.2(typescript@7.0.2)
       debug: 4.4.3
       env-ci: 11.2.0
       execa: 9.6.1
@@ -9195,9 +9366,9 @@ snapshots:
 
   traverse@0.6.8: {}
 
-  ts-api-utils@2.5.0(typescript@6.0.3):
+  ts-api-utils@2.5.0(typescript@7.0.2):
     dependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tsconfig-paths@3.15.0:
     dependencies:
@@ -9266,18 +9437,39 @@ snapshots:
       possible-typed-array-names: 1.1.0
       reflect.getprototypeof: 1.0.10
 
-  typescript-eslint@8.63.0(eslint@10.6.0)(typescript@6.0.3):
+  typescript-eslint@8.63.0(eslint@10.9.0)(typescript@7.0.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0)(typescript@6.0.3))(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.63.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.6.0)(typescript@6.0.3)
-      eslint: 10.6.0
-      typescript: 6.0.3
+      '@typescript-eslint/eslint-plugin': 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.9.0)(typescript@7.0.2))(eslint@10.9.0)(typescript@7.0.2)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
+      '@typescript-eslint/typescript-estree': 8.63.0(typescript@7.0.2)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.9.0)(typescript@7.0.2)
+      eslint: 10.9.0
+      typescript: 7.0.2
     transitivePeerDependencies:
       - supports-color
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uglify-js@3.19.3:
     optional: true
@@ -9371,15 +9563,15 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)):
+  vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)):
     dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
       es-module-lexer: 2.3.0
       expect-type: 1.4.0
       magic-string: 0.30.21

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,7 @@ allowBuilds:
 
 overrides:
   "@grpc/grpc-js": ">=1.14.4"
+  "@types/node": "^24"
   "@tootallnate/once": "^3.0.1"
   brace-expansion: ">=5.0.9"
   defu: "^6.1.5"

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -174,8 +174,8 @@ write_tsconfig() {
 	cat > "$CONSUMER/tsconfig.$1.json" <<EOF
 {
   "compilerOptions": {
-    "module": "$2",
-    "moduleResolution": "$1",
+    "module": "$3",
+    "moduleResolution": "$2",
     "target": "ES2022",
     "lib": ["ES2022", "DOM"],
     "strict": true,
@@ -187,16 +187,38 @@ write_tsconfig() {
 }
 EOF
 }
-write_tsconfig nodenext nodenext
-write_tsconfig bundler preserve
+
+# `module: "preserve"` is what a modern bundler setup uses, but it only exists
+# from TypeScript 5.4. The peer range is ">=5.0.0" and the declarations really do
+# work that far back, so `esnext` carries the bundler check across the whole
+# range and `preserve` is layered on when the compiler under test understands it.
+# Without this, pointing TSC at a 5.0-5.3 compiler fails on the fixture rather
+# than on the package, and the bottom of the declared range cannot be verified.
+TS_VERSION="$(node -p "require('$(dirname "$TSC")/../package.json').version")"
+TS_MAJOR="${TS_VERSION%%.*}"
+TS_REST="${TS_VERSION#*.}"
+TS_MINOR="${TS_REST%%.*}"
+
+CHECKS=("nodenext:nodenext:nodenext" "bundler-esnext:bundler:esnext")
+if (( TS_MAJOR > 5 )) || (( TS_MAJOR == 5 && TS_MINOR >= 4 )); then
+	CHECKS+=("bundler-preserve:bundler:preserve")
+else
+	echo "note: TypeScript $TS_VERSION predates module: \"preserve\"; skipping that check"
+fi
+
+for check in "${CHECKS[@]}"; do
+	IFS=: read -r name resolution mod <<< "$check"
+	write_tsconfig "$name" "$resolution" "$mod"
+done
 
 echo "==> resolving entry points"
 (cd "$CONSUMER" && node ./esm-smoke.mjs && node ./cjs-smoke.cjs)
 
-echo "==> type-checking a consumer"
-for resolution in nodenext bundler; do
-	(cd "$CONSUMER" && node "$TSC" -p "tsconfig.$resolution.json")
-	echo "    ok  moduleResolution: \"$resolution\""
+echo "==> type-checking a consumer (TypeScript $TS_VERSION)"
+for check in "${CHECKS[@]}"; do
+	IFS=: read -r name resolution mod <<< "$check"
+	(cd "$CONSUMER" && node "$TSC" -p "tsconfig.$name.json")
+	echo "    ok  moduleResolution: \"$resolution\", module: \"$mod\""
 done
 
 echo "==> packaging smoke test passed"

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+#
+# Packaging smoke test.
+#
+# The unit tests import from src/, so nothing exercises what npm actually
+# publishes. This packs the tarball, installs it into a throwaway consumer
+# alongside the peer deps, and asserts that every published entry point
+# resolves at runtime and keeps its types.
+#
+# Requires `pnpm build` to have run first. Run locally with `pnpm verify:pack`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_NAME="better-auth-firebase-auth"
+PEERS=("better-auth" "firebase" "firebase-admin")
+
+actual_name="$(cd "$REPO_ROOT" && node -p 'require("./package.json").name')"
+if [[ "$actual_name" != "$PKG_NAME" ]]; then
+	echo "error: package is now named '$actual_name'; update the fixtures in $0" >&2
+	exit 1
+fi
+
+if [[ ! -f "$REPO_ROOT/dist/index.js" ]]; then
+	echo "error: dist/ is missing or incomplete. Run \`pnpm build\` first." >&2
+	exit 1
+fi
+
+TSC="$REPO_ROOT/node_modules/typescript/bin/tsc"
+if [[ ! -f "$TSC" ]]; then
+	echo "error: typescript not found at $TSC. Run \`pnpm install\` first." >&2
+	exit 1
+fi
+
+# Outside the repo on purpose: inside it, the pnpm workspace root would capture
+# the consumer install.
+WORK="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/pack-smoke.XXXXXX")"
+if [[ -n "${PACK_SMOKE_KEEP:-}" ]]; then
+	echo "note: keeping $WORK (PACK_SMOKE_KEEP is set)"
+else
+	trap 'rm -rf "$WORK"' EXIT
+fi
+
+CONSUMER="$WORK/consumer"
+mkdir -p "$CONSUMER"
+
+echo "==> npm pack"
+(cd "$REPO_ROOT" && npm pack --silent --pack-destination "$WORK" >/dev/null)
+TARBALL="$(find "$WORK" -maxdepth 1 -name '*.tgz' -print -quit)"
+if [[ -z "$TARBALL" ]]; then
+	echo "error: npm pack produced no tarball" >&2
+	exit 1
+fi
+echo "    $(basename "$TARBALL")"
+
+# Pin the peers to the ranges the test suite already runs against, so this
+# never drifts from package.json.
+PEER_DEPS="$(cd "$REPO_ROOT" && node -p '
+	const dev = require("./package.json").devDependencies ?? {};
+	const peers = process.argv.slice(1);
+	const missing = peers.filter((name) => !dev[name]);
+	if (missing.length > 0) {
+		console.error(`error: no devDependency range for ${missing.join(", ")}`);
+		process.exit(1);
+	}
+	JSON.stringify(Object.fromEntries(peers.map((name) => [name, dev[name]])), null, 2);
+' "${PEERS[@]}")"
+
+cat > "$CONSUMER/package.json" <<EOF
+{
+  "name": "pack-smoke-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": $PEER_DEPS
+}
+EOF
+
+# pnpm, not npm: the store is already warm from the install earlier in the job,
+# so the peers come from hard links instead of a ~270MB download. Its default
+# isolated layout is also stricter than npm's hoisting -- a dependency the
+# package failed to declare fails here rather than resolving by accident.
+echo "==> installing the tarball next to ${PEERS[*]}"
+(cd "$CONSUMER" && pnpm add --ignore-workspace --ignore-scripts --reporter=silent "$TARBALL")
+
+cat > "$CONSUMER/esm-smoke.mjs" <<'EOF'
+const entries = [
+	[
+		"better-auth-firebase-auth",
+		["firebaseAuthPlugin", "firebaseAuthClientPlugin", "extractOobCodeFromUrl"],
+	],
+	["better-auth-firebase-auth/server", ["firebaseAuthPlugin"]],
+	[
+		"better-auth-firebase-auth/client",
+		["firebaseAuthClientPlugin", "extractOobCodeFromUrl"],
+	],
+];
+
+for (const [specifier, expected] of entries) {
+	const mod = await import(specifier);
+	const missing = expected.filter((name) => typeof mod[name] !== "function");
+	if (missing.length > 0) {
+		throw new Error(`import("${specifier}") is missing: ${missing.join(", ")}`);
+	}
+	console.log(`    ok  import("${specifier}")`);
+}
+EOF
+
+cat > "$CONSUMER/cjs-smoke.cjs" <<'EOF'
+// The package is ESM-only, so this leans on Node's require(esm) support (>= 22.12).
+const mod = require("better-auth-firebase-auth");
+const expected = [
+	"firebaseAuthPlugin",
+	"firebaseAuthClientPlugin",
+	"extractOobCodeFromUrl",
+];
+const missing = expected.filter((name) => typeof mod[name] !== "function");
+if (missing.length > 0) {
+	throw new Error(`require("better-auth-firebase-auth") is missing: ${missing.join(", ")}`);
+}
+console.log('    ok  require("better-auth-firebase-auth")');
+EOF
+
+cat > "$CONSUMER/consumer.ts" <<'EOF'
+import {
+	extractOobCodeFromUrl,
+	firebaseAuthClientPlugin,
+	firebaseAuthPlugin,
+} from "better-auth-firebase-auth";
+import type {
+	AuthResponse,
+	ConfirmPasswordResetRequest,
+	FirebaseAuthPluginOptions,
+	SignInWithGoogleRequest,
+	VerifyPasswordResetCodeResponse,
+} from "better-auth-firebase-auth";
+
+const options: FirebaseAuthPluginOptions = {
+	serverSideOnly: true,
+	sessionExpiresInDays: 7,
+	passwordResetUrl: "https://example.test/reset",
+};
+
+export const pluginId: string = firebaseAuthPlugin(options).id;
+export const clientPlugin = firebaseAuthClientPlugin(options);
+export const oobCode: string | null = extractOobCodeFromUrl(
+	"https://example.test/reset?oobCode=abc",
+);
+
+export const googleRequest: SignInWithGoogleRequest = { idToken: "id-token" };
+export const confirmReset: ConfirmPasswordResetRequest = {
+	oobCode: "abc",
+	newPassword: "hunter2",
+};
+export const verifyResponse: VerifyPasswordResetCodeResponse = {
+	valid: true,
+	email: "user@example.test",
+};
+export const authResponse: AuthResponse = {
+	user: { id: "u1", email: null, name: null, image: null },
+	session: { id: "s1", expiresAt: new Date(), token: "t" },
+};
+
+// If the published declarations degrade to `any` -- which is how the nodenext
+// breakage showed up -- these stop erroring, and tsc then reports the
+// directives themselves as unused, failing the check.
+// @ts-expect-error sessionExpiresInDays is a number, not a string.
+export const badOptions: FirebaseAuthPluginOptions = { sessionExpiresInDays: "7" };
+// @ts-expect-error valid is a boolean, not a string.
+export const badResponse: VerifyPasswordResetCodeResponse = { valid: "yes", email: "" };
+EOF
+
+write_tsconfig() {
+	cat > "$CONSUMER/tsconfig.$1.json" <<EOF
+{
+  "compilerOptions": {
+    "module": "$2",
+    "moduleResolution": "$1",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "files": ["consumer.ts"]
+}
+EOF
+}
+write_tsconfig nodenext nodenext
+write_tsconfig bundler preserve
+
+echo "==> resolving entry points"
+(cd "$CONSUMER" && node ./esm-smoke.mjs && node ./cjs-smoke.cjs)
+
+echo "==> type-checking a consumer"
+for resolution in nodenext bundler; do
+	(cd "$CONSUMER" && node "$TSC" -p "tsconfig.$resolution.json")
+	echo "    ok  moduleResolution: \"$resolution\""
+done
+
+echo "==> packaging smoke test passed"

--- a/src/firebase-auth-client-plugin.test.ts
+++ b/src/firebase-auth-client-plugin.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	extractOobCodeFromUrl,
 	firebaseAuthClientPlugin,
-} from "./firebase-auth-client-plugin";
+} from "./firebase-auth-client-plugin.js";
 
 describe("firebaseAuthClientPlugin", () => {
 	const mockFetch = vi.fn();

--- a/src/firebase-auth-client-plugin.ts
+++ b/src/firebase-auth-client-plugin.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "better-auth/client";
-import type { firebaseAuthPlugin } from "./firebase-auth-plugin";
+import type { firebaseAuthPlugin } from "./firebase-auth-plugin.js";
 import type {
 	AuthResponse,
 	ConfirmPasswordResetRequest,
@@ -10,7 +10,7 @@ import type {
 	SignInWithPhoneRequest,
 	VerifyPasswordResetCodeRequest,
 	VerifyPasswordResetCodeResponse,
-} from "./types";
+} from "./types.js";
 
 type FirebaseAuthPlugin = typeof firebaseAuthPlugin;
 

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -1,6 +1,9 @@
 import { setSessionCookie } from "better-auth/cookies";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createOrUpdateUser, firebaseAuthPlugin } from "./firebase-auth-plugin";
+import {
+	createOrUpdateUser,
+	firebaseAuthPlugin,
+} from "./firebase-auth-plugin.js";
 
 vi.mock("firebase-admin/auth", () => ({
 	getAuth: vi.fn(() => ({

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -2,6 +2,7 @@ import { setSessionCookie } from "better-auth/cookies";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	createOrUpdateUser,
+	FIREBASE_ACCOUNT_ISSUER,
 	firebaseAuthPlugin,
 } from "./firebase-auth-plugin.js";
 
@@ -161,7 +162,7 @@ describe("firebaseAuthPlugin", () => {
 
 	describe("createOrUpdateUser", () => {
 		describe("new user (no existing OAuth or email match)", () => {
-			it("should call findOAuthUser with correct args", async () => {
+			it("should look up the Firebase account via findOAuthUser (better-auth < 1.7)", async () => {
 				const ctx = createMockCtx();
 				await createOrUpdateUser(ctx as any, mockDecodedToken, "id-token-abc");
 
@@ -176,12 +177,18 @@ describe("firebaseAuthPlugin", () => {
 				const ctx = createMockCtx();
 				await createOrUpdateUser(ctx as any, mockDecodedToken, "id-token-abc");
 
-				expect(mockInternalAdapter.createUser).toHaveBeenCalledWith({
-					email: "test@example.com",
-					name: "Test User",
-					image: "https://example.com/photo.jpg",
-					emailVerified: true,
-				});
+				expect(mockInternalAdapter.createUser).toHaveBeenCalledWith(
+					{
+						email: "test@example.com",
+						name: "Test User",
+						image: "https://example.com/photo.jpg",
+						emailVerified: true,
+					},
+					{
+						method: "oauth",
+						oauth: { providerId: "firebase", profile: mockDecodedToken },
+					},
+				);
 			});
 
 			it("should link a new account with correct field names", async () => {
@@ -190,6 +197,7 @@ describe("firebaseAuthPlugin", () => {
 
 				expect(mockInternalAdapter.linkAccount).toHaveBeenCalledWith({
 					providerId: "firebase",
+					issuer: FIREBASE_ACCOUNT_ISSUER,
 					accountId: "firebase-uid-123",
 					userId: "user-123",
 					idToken: "id-token-abc",
@@ -336,11 +344,127 @@ describe("firebaseAuthPlugin", () => {
 
 				expect(mockInternalAdapter.linkAccount).toHaveBeenCalledWith({
 					providerId: "firebase",
+					issuer: FIREBASE_ACCOUNT_ISSUER,
 					accountId: "firebase-uid-123",
 					userId: "user-123",
 					idToken: "id-token-abc",
 					accessTokenExpiresAt: expect.any(Date),
 				});
+			});
+		});
+
+		describe("better-auth >= 1.7 adapter (findAccountOwnerByKey)", () => {
+			// 1.7 removed findOAuthUser and keys accounts by (issuer, accountId)
+			const { findOAuthUser: _legacy, ...modernMethods } = mockInternalAdapter;
+			const modernAdapter = {
+				...modernMethods,
+				findAccountOwnerByKey: vi.fn(),
+			};
+			const createModernCtx = () => ({
+				context: { internalAdapter: modernAdapter },
+				body: {},
+				json: vi.fn((data: any) =>
+					Promise.resolve(new Response(JSON.stringify(data))),
+				),
+			});
+
+			beforeEach(() => {
+				modernAdapter.findAccountOwnerByKey.mockResolvedValue(null);
+			});
+
+			it("should look up the account by issuer + accountId and never call findOAuthUser", async () => {
+				await createOrUpdateUser(
+					createModernCtx() as any,
+					mockDecodedToken,
+					"id-token-abc",
+				);
+
+				expect(modernAdapter.findAccountOwnerByKey).toHaveBeenCalledWith({
+					issuer: FIREBASE_ACCOUNT_ISSUER,
+					accountId: "firebase-uid-123",
+				});
+				expect(FIREBASE_ACCOUNT_ISSUER).toBe("local:oauth:firebase");
+				expect(mockInternalAdapter.findOAuthUser).not.toHaveBeenCalled();
+			});
+
+			it("should create the user with a provisioning source and link with issuer when no account exists", async () => {
+				await createOrUpdateUser(
+					createModernCtx() as any,
+					mockDecodedToken,
+					"id-token-abc",
+				);
+
+				expect(modernAdapter.findUserByEmail).toHaveBeenCalledWith(
+					"test@example.com",
+				);
+				expect(modernAdapter.createUser).toHaveBeenCalledWith(
+					expect.objectContaining({ email: "test@example.com" }),
+					{
+						method: "oauth",
+						oauth: { providerId: "firebase", profile: mockDecodedToken },
+					},
+				);
+				expect(modernAdapter.linkAccount).toHaveBeenCalledWith(
+					expect.objectContaining({
+						providerId: "firebase",
+						issuer: FIREBASE_ACCOUNT_ISSUER,
+						accountId: "firebase-uid-123",
+						userId: "user-123",
+					}),
+				);
+			});
+
+			it("should reuse the owner when the account is owned", async () => {
+				modernAdapter.findAccountOwnerByKey.mockResolvedValue({
+					kind: "owned",
+					user: mockUser,
+					account: mockAccount,
+				});
+
+				await createOrUpdateUser(
+					createModernCtx() as any,
+					mockDecodedToken,
+					"id-token-abc",
+				);
+
+				expect(modernAdapter.findUserByEmail).not.toHaveBeenCalled();
+				expect(modernAdapter.createUser).not.toHaveBeenCalled();
+				expect(modernAdapter.updateUser).toHaveBeenCalledWith(
+					"user-123",
+					expect.any(Object),
+				);
+				expect(modernAdapter.linkAccount).not.toHaveBeenCalled();
+				expect(modernAdapter.updateAccount).toHaveBeenCalledWith(
+					"account-456",
+					expect.objectContaining({ idToken: "id-token-abc" }),
+				);
+			});
+
+			it("should fall back to email lookup when the account is orphaned", async () => {
+				modernAdapter.findAccountOwnerByKey.mockResolvedValue({
+					kind: "orphaned",
+					account: mockAccount,
+				});
+				modernAdapter.findUserByEmail.mockResolvedValue({
+					user: mockUser,
+					accounts: [],
+				});
+
+				await createOrUpdateUser(
+					createModernCtx() as any,
+					mockDecodedToken,
+					"id-token-abc",
+				);
+
+				expect(modernAdapter.findUserByEmail).toHaveBeenCalledWith(
+					"test@example.com",
+				);
+				expect(modernAdapter.createUser).not.toHaveBeenCalled();
+				expect(modernAdapter.linkAccount).not.toHaveBeenCalled();
+				expect(modernAdapter.updateAccount).toHaveBeenCalledWith(
+					"account-456",
+					expect.any(Object),
+				);
 			});
 		});
 
@@ -354,7 +478,7 @@ describe("firebaseAuthPlugin", () => {
 				exp: Math.floor(Date.now() / 1000) + 3600,
 			};
 
-			it("should pass empty string as email to findOAuthUser", async () => {
+			it("should pass empty string as email to findOAuthUser (better-auth < 1.7)", async () => {
 				const ctx = createMockCtx();
 				await createOrUpdateUser(ctx as any, tokenNoEmail, "id-token");
 
@@ -376,12 +500,18 @@ describe("firebaseAuthPlugin", () => {
 				const ctx = createMockCtx();
 				await createOrUpdateUser(ctx as any, tokenNoEmail, "id-token");
 
-				expect(mockInternalAdapter.createUser).toHaveBeenCalledWith({
-					email: "",
-					name: "No Email User",
-					image: undefined,
-					emailVerified: false,
-				});
+				expect(mockInternalAdapter.createUser).toHaveBeenCalledWith(
+					{
+						email: "",
+						name: "No Email User",
+						image: undefined,
+						emailVerified: false,
+					},
+					{
+						method: "oauth",
+						oauth: { providerId: "firebase", profile: tokenNoEmail },
+					},
+				);
 			});
 		});
 

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -7,7 +7,7 @@ import {
 import { setSessionCookie } from "better-auth/cookies";
 import type { FirebaseOptions } from "firebase/app";
 import { getAuth } from "firebase-admin/auth";
-import type { AuthResponse, FirebaseAuthPluginOptions } from "./types";
+import type { AuthResponse, FirebaseAuthPluginOptions } from "./types.js";
 
 type DecodedToken = {
 	uid: string;

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -1,4 +1,9 @@
-import type { BetterAuthPlugin, GenericEndpointContext } from "better-auth";
+import type {
+	Account,
+	BetterAuthPlugin,
+	GenericEndpointContext,
+	User,
+} from "better-auth";
 import {
 	APIError,
 	createAuthEndpoint,
@@ -8,6 +13,21 @@ import { setSessionCookie } from "better-auth/cookies";
 import type { FirebaseOptions } from "firebase/app";
 import { getAuth } from "firebase-admin/auth";
 import type { AuthResponse, FirebaseAuthPluginOptions } from "./types.js";
+
+/**
+ * Issuer stored on Firebase-linked `account` rows.
+ *
+ * Better Auth >= 1.7 identifies accounts by the `(issuer, accountId)` pair and
+ * requires `issuer` on every row. Firebase is not a configured OIDC provider in
+ * Better Auth, so the plugin uses the synthetic issuer Better Auth derives for
+ * OAuth providers without one (`createOAuthAccountIssuer("firebase")`).
+ *
+ * When upgrading an existing database to Better Auth 1.7, backfill this value
+ * on rows where `providerId = 'firebase'` before making `issuer` NOT NULL.
+ */
+export const FIREBASE_ACCOUNT_ISSUER = "local:oauth:firebase";
+
+const FIREBASE_PROVIDER_ID = "firebase";
 
 type DecodedToken = {
 	uid: string;
@@ -19,6 +39,55 @@ type DecodedToken = {
 	exp?: number;
 };
 
+type InternalAdapter = GenericEndpointContext["context"]["internalAdapter"];
+
+/** `internalAdapter` surface of Better Auth 1.5 – 1.6 (removed in 1.7). */
+type LegacyInternalAdapter = {
+	findOAuthUser: (
+		email: string,
+		accountId: string,
+		providerId: string,
+	) => Promise<{
+		user: User;
+		linkedAccount: Pick<Account, "id"> | null;
+	} | null>;
+};
+
+/**
+ * Find the Better Auth user linked to a Firebase UID.
+ *
+ * Better Auth >= 1.7 keys accounts by `(issuer, accountId)` and removed
+ * `findOAuthUser`; 1.5 – 1.6 key them by `(providerId, accountId)`. Feature
+ * detection keeps a single build working across both lines.
+ */
+const findFirebaseAccountOwner = async (
+	internalAdapter: InternalAdapter,
+	decodedToken: DecodedToken,
+): Promise<{ user: User | null; account: Pick<Account, "id"> | null }> => {
+	if ("findAccountOwnerByKey" in internalAdapter) {
+		const owner = await internalAdapter.findAccountOwnerByKey({
+			issuer: FIREBASE_ACCOUNT_ISSUER,
+			accountId: decodedToken.uid,
+		});
+		return {
+			user: owner?.kind === "owned" ? owner.user : null,
+			account: owner?.account ?? null,
+		};
+	}
+
+	const legacy = await (
+		internalAdapter as unknown as LegacyInternalAdapter
+	).findOAuthUser(
+		decodedToken.email || "",
+		decodedToken.uid,
+		FIREBASE_PROVIDER_ID,
+	);
+	return {
+		user: legacy?.user ?? null,
+		account: legacy?.linkedAccount ?? null,
+	};
+};
+
 export const createOrUpdateUser = async (
 	ctx: GenericEndpointContext,
 	decodedToken: DecodedToken,
@@ -27,15 +96,9 @@ export const createOrUpdateUser = async (
 ): Promise<AuthResponse> => {
 	const { internalAdapter } = ctx.context;
 
-	let user = null;
-	const oauthUser = await internalAdapter.findOAuthUser(
-		decodedToken.email || "",
-		decodedToken.uid,
-		"firebase",
-	);
-
-	user = oauthUser?.user ?? null;
-	const existingAccount = oauthUser?.linkedAccount ?? null;
+	const { user: linkedUser, account: existingAccount } =
+		await findFirebaseAccountOwner(internalAdapter, decodedToken);
+	let user = linkedUser;
 
 	if (!user && decodedToken.email) {
 		const found = await internalAdapter.findUserByEmail(decodedToken.email);
@@ -43,12 +106,20 @@ export const createOrUpdateUser = async (
 	}
 
 	if (!user) {
-		user = await internalAdapter.createUser({
-			email: decodedToken.email || "",
-			name: decodedToken.name || "",
-			image: decodedToken.picture || undefined,
-			emailVerified: decodedToken.email_verified || false,
-		});
+		user = await internalAdapter.createUser(
+			{
+				email: decodedToken.email || "",
+				name: decodedToken.name || "",
+				image: decodedToken.picture || undefined,
+				emailVerified: decodedToken.email_verified || false,
+			},
+			// Provisioning source for `user.validateUserInfo` (Better Auth >= 1.7);
+			// ignored by older versions.
+			{
+				method: "oauth",
+				oauth: { providerId: FIREBASE_PROVIDER_ID, profile: decodedToken },
+			},
+		);
 	} else {
 		user = await internalAdapter.updateUser(user.id, {
 			name: decodedToken.name || user.name,
@@ -59,7 +130,8 @@ export const createOrUpdateUser = async (
 
 	if (!existingAccount) {
 		await internalAdapter.linkAccount({
-			providerId: "firebase",
+			providerId: FIREBASE_PROVIDER_ID,
+			issuer: FIREBASE_ACCOUNT_ISSUER,
 			accountId: decodedToken.uid,
 			userId: user.id,
 			idToken,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export {
 	extractOobCodeFromUrl,
 	firebaseAuthClientPlugin,
-} from "./firebase-auth-client-plugin";
-export { firebaseAuthPlugin } from "./firebase-auth-plugin";
-export type * from "./types";
+} from "./firebase-auth-client-plugin.js";
+export { firebaseAuthPlugin } from "./firebase-auth-plugin.js";
+export type * from "./types.js";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,9 +4,9 @@
     "outDir": "dist",
     "declaration": true,
     "emitDeclarationOnly": false,
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ES2020",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "NodeNext",
     "rootDir": "src",
     "noEmit": false
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Better Auth 1.7 keys accounts by `(issuer, accountId)`, requires `issuer` on every account row, and removed `internalAdapter.findOAuthUser` — so on 1.7 every sign-in endpoint of this plugin returned 500. While fixing that, the stack also repairs both package entry points (the root `import` threw `ERR_MODULE_NOT_FOUND`; `require()` pointed at a file no release ever contained) and the `typescript` peer that made `npm install` fail on TS 6/7. Upgrade guide: https://better-auth.com/docs/guides/1-7-upgrade-guide

## Changes

- **Better Auth 1.7 support, 1.5/1.6 unchanged** — `createOrUpdateUser` feature-detects the adapter API (`findAccountOwnerByKey` on ≥ 1.7, `findOAuthUser` before). Linked accounts carry `issuer: "local:oauth:firebase"` (exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server` for migration scripts), and `createUser` passes a provisioning source so `user.validateUserInfo` sees Firebase sign-ups as `method: "oauth"`, `providerId: "firebase"`. Peer range stays `>=1.5.0` — one build, no second release line.
- **Root entry importable again** — `tsc` emitted extensionless relative specifiers, so `import("better-auth-firebase-auth")` threw `ERR_MODULE_NOT_FOUND` and every `dist/*.d.ts` broke under `moduleResolution: node16`/`nodenext` (types silently vanished with `skipLibCheck`). Explicit `.js` specifiers + `NodeNext` tsconfigs. `/server` and `/client` subpaths were unaffected.
- **`require()` works on Node ≥ 22.12** — `main`/`exports["."].require` pointed at `dist/index.cjs`, which no published version ever contained. The package is now explicitly ESM-only with `default` conditions (mirroring better-auth's own packaging), so `require()` resolves via `require(esm)`.
- **TypeScript 6/7** — the `typescript` peer was `^5.0.0` while `latest` is 7.x, so `npm install` failed with ERESOLVE. Now `>=5.0.0`; `dist/` output verified byte-identical across TS 5.0/5.9/6.0/7.0.
- **CI** — better-auth 1.5/1.6/1.7 test matrix; packed-artifact smoke test (`pnpm verify:pack`: import/require/type-check of the tarball across the TS peer range).
- **Docs** — README: 1.7 compatibility table, the one-time `issuer` backfill, callout at the top; `.github/RELEASE.md` documenting what renders in release notes; AGENTS.md account-storage notes brought in line with the code.
- **Housekeeping (no release impact)** — dev-deps group bump (#46: TS 7.0.2, biome 2.5.9, vitest 4.1.11, semantic-release 25.0.9, …), drop never-imported `better-sqlite3` devDependency (#50), pin `@types/node` to the Node 24 LTS line via workspace override.

## Upgrading (existing deployments on Better Auth 1.7)

1.7 has no `providerId` fallback, and `npx auth migrate` refuses to add a `NOT NULL` column to a populated table. Before the first deploy on 1.7: add `issuer` as nullable, then

```sql
UPDATE account SET issuer = 'local:oauth:firebase' WHERE "providerId" = 'firebase';
```

then make it `NOT NULL` with the unique `(issuer, accountId)` index. Skipping it doesn't lock users out — the plugin re-links by email — but leaves the old row orphaned. Details: README → *Upgrading an existing app to Better Auth 1.7*.

## Testing

70/70 tests on better-auth 1.7.1, 1.6.30 and 1.5.6 (13 against a real better-auth instance); build clean on TypeScript 7.0.2; `verify:pack` green; `pnpm audit` clean.

## Merging

**Use “Rebase and merge.”** Each `feat`/`fix` subject becomes one line in the v2.2.0 release notes (the `feat` commit makes it a minor); squash would collapse the notes to a single line. After the release is published, append the block below to the GitHub Release body — commit bodies never render, so the operational steps live nowhere else:

<details>
<summary>Release notes to append after publish</summary>

```markdown
## Upgrade notes

**Better Auth 1.7 with existing users — backfill `account.issuer` before your first deploy on 1.7.** 1.7 looks accounts up by `(issuer, accountId)` and pre-1.7 rows don't have the field. Add `issuer` as a nullable column, run

    UPDATE account SET issuer = 'local:oauth:firebase' WHERE "providerId" = 'firebase';

(other providers per the [Better Auth upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer)), then make it `NOT NULL` with the unique `(issuer, accountId)` index (`npx auth migrate` can finish this step). The value is exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server`. Skipping the backfill doesn't lock users out — the plugin falls back to matching by email and re-links — but it leaves the old account row orphaned. Details: [README → Upgrading an existing app to Better Auth 1.7](https://github.com/yultyyev/better-auth-firebase-auth#upgrading-an-existing-app-to-better-auth-17).

- **Better Auth 1.5 and 1.6 keep working** with this release; CI tests 1.5, 1.6 and 1.7.
- **`require("better-auth-firebase-auth")` now works** on Node ≥ 22.12 (`require(esm)`); the package is ESM-only.
- **The root import works again** — it previously threw `ERR_MODULE_NOT_FOUND` (the `/server` and `/client` subpaths were unaffected), and its types no longer vanish under `moduleResolution: node16`/`nodenext`.
- **TypeScript 6 and 7 are supported** — the `typescript` peer is now `>=5.0.0`, so `npm install` no longer fails with ERESOLVE.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
