### PR TITLE
chore(release-policy): stop dependency bumps from publishing

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,16 +4,7 @@
     { "name": "next", "prerelease": "alpha", "channel": "alpha" }
   ],
   "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "angular",
-        "releaseRules": [
-          { "type": "chore", "scope": "deps", "release": "patch" },
-          { "type": "chore", "scope": "security", "release": "patch" }
-        ]
-      }
-    ],
+    ["@semantic-release/commit-analyzer", { "preset": "angular" }],
     "@semantic-release/release-notes-generator",
     ["@semantic-release/changelog", { "changelogFile": "CHANGELOG.md" }],
     ["@semantic-release/npm", { "tarballDir": "release", "npmPublish": false }],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,20 @@ Follow Conventional Commits format:
 - `chore: description` - Build/tooling changes
 - `test(server): description` - Test changes
 
+### What publishes a release
+
+`semantic-release` publishes from `feat` (minor) and `fix` (patch) commits.
+`chore`, `docs`, and `test` never publish, and never appear in the changelog.
+
+Dependency bumps land as `chore(deps)` / `chore(deps-dev)` and are inert on
+purpose: the package ships only `dist/` and declares every runtime dependency
+as a peer, so a bump cannot change the published artifact. Merge Dependabot
+PRs as-is.
+
+Use `fix(deps):` or `fix(security):` when a change *should* reach consumers --
+a `peerDependencies` range change, or a rebuild worth publishing. Those cut a
+patch and show up in the changelog under Bug Fixes.
+
 ## References
 
 - [Better Auth Plugin Guide](https://www.better-auth.com/docs/guides/your-first-plugin)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,13 @@ pnpm lint:fix
    chore: update dependencies to latest versions
    ```
 
+   Only `feat` and `fix` publish a release. `chore`, `docs`, and `test` do not,
+   and are omitted from the changelog. Dependency bumps are `chore(deps)` and
+   stay inert -- the package ships only `dist/` and declares every runtime
+   dependency as a peer, so a bump cannot change what consumers install. Reach
+   for `fix(deps):` or `fix(security):` when a change genuinely needs to be
+   published.
+
 8. Push your branch to your fork
 
 9. Open a pull request against the **main** branch. In your PR description:


### PR DESCRIPTION
Drops the two custom `releaseRules` that mapped `chore(deps)` and
`chore(security)` to a `patch`. semantic-release then falls back to standard
conventional-commits behaviour.

**This PR does not itself publish** — `chore(release-policy)` is inert under
both the old rules and the new ones.

## Why

The rules were mis-calibrated for this package:

- It ships only `dist/` (`files: ["dist", "README.md", "LICENSE"]`).
- It has **no runtime dependencies at all** — `better-auth`, `firebase`,
  `firebase-admin`, and `typescript` are every one of them `peerDependencies`.

So a dependency bump cannot change the published artifact. Each `chore(deps)`
merge published a byte-identical tarball under a new version number.

Those releases were also invisible. `@semantic-release/release-notes-generator`
omits `chore` commits regardless of scope, so a dependency-triggered release
produced a changelog entry containing nothing but its own version header:

```
## [1.0.1](.../compare/v1.0.0...v1.0.1) (2026-08-23)
```

That is the complete output for a batch of four dependency merges.

## Behaviour change

Verified against the repo's own `commit-analyzer`, before and after:

| commit | before | after |
| --- | --- | --- |
| `chore(deps): bump react-dom and @types/react-dom` | patch | — |
| `chore(deps): bump firebase-admin from 13.8.0 to 14.2.0` | patch | — |
| `chore(deps-dev): bump the dev-dependencies group` | — | — |
| `chore(security): aggregate dependency updates` | patch | — |
| `fix(security): rebuild with patched toolchain` | patch | patch |
| `fix(deps): widen typescript peer range to ^5 \|\| ^6` | patch | patch |
| `fix(server): resolve token verification error` | patch | patch |
| `feat(firebase-auth): add phone number authentication` | minor | minor |

Net effect: Dependabot PRs can be merged as-is without publishing, and no
per-PR squash-subject rewriting is needed to hold a release back.

When a change genuinely should reach consumers — a `peerDependencies` range
change, or a rebuild worth shipping — write it as `fix(deps):` or
`fix(security):`. Those cut a patch *and* land in the changelog under Bug
Fixes, which `chore(security)` never did.

## Docs

[AGENTS.md](AGENTS.md) and [CONTRIBUTING.md](CONTRIBUTING.md) get a short note
on which types publish, so the convention is discoverable rather than implicit
in `.releaserc.json`.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm audit --audit-level=moderate` — no known vulnerabilities
- `pnpm lint` / `pnpm build` / `pnpm test` — pass, 66/66

`.releaserc.json` re-parsed as valid JSON after the edit. No source files
touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
