### PR TITLE
fix(build): repair both broken package entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,22 +6,21 @@
   "author": "Slava Yultyyev <yultyyev@gmail.com>",
   "license": "MIT",
   "type": "module",
-  "main": "./dist/index.cjs",
+  "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "default": "./dist/index.js"
     },
     "./client": {
       "types": "./dist/firebase-auth-client-plugin.d.ts",
-      "import": "./dist/firebase-auth-client-plugin.js"
+      "default": "./dist/firebase-auth-client-plugin.js"
     },
     "./server": {
       "types": "./dist/firebase-auth-plugin.d.ts",
-      "import": "./dist/firebase-auth-plugin.js"
+      "default": "./dist/firebase-auth-plugin.js"
     }
   },
   "files": [

--- a/src/firebase-auth-client-plugin.test.ts
+++ b/src/firebase-auth-client-plugin.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	extractOobCodeFromUrl,
 	firebaseAuthClientPlugin,
-} from "./firebase-auth-client-plugin";
+} from "./firebase-auth-client-plugin.js";
 
 describe("firebaseAuthClientPlugin", () => {
 	const mockFetch = vi.fn();

--- a/src/firebase-auth-client-plugin.ts
+++ b/src/firebase-auth-client-plugin.ts
@@ -1,5 +1,5 @@
 import type { BetterAuthClientPlugin } from "better-auth/client";
-import type { firebaseAuthPlugin } from "./firebase-auth-plugin";
+import type { firebaseAuthPlugin } from "./firebase-auth-plugin.js";
 import type {
 	AuthResponse,
 	ConfirmPasswordResetRequest,
@@ -10,7 +10,7 @@ import type {
 	SignInWithPhoneRequest,
 	VerifyPasswordResetCodeRequest,
 	VerifyPasswordResetCodeResponse,
-} from "./types";
+} from "./types.js";
 
 type FirebaseAuthPlugin = typeof firebaseAuthPlugin;
 

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -1,6 +1,9 @@
 import { setSessionCookie } from "better-auth/cookies";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createOrUpdateUser, firebaseAuthPlugin } from "./firebase-auth-plugin";
+import {
+	createOrUpdateUser,
+	firebaseAuthPlugin,
+} from "./firebase-auth-plugin.js";
 
 vi.mock("firebase-admin/auth", () => ({
 	getAuth: vi.fn(() => ({

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -7,7 +7,7 @@ import {
 import { setSessionCookie } from "better-auth/cookies";
 import type { FirebaseOptions } from "firebase/app";
 import { getAuth } from "firebase-admin/auth";
-import type { AuthResponse, FirebaseAuthPluginOptions } from "./types";
+import type { AuthResponse, FirebaseAuthPluginOptions } from "./types.js";
 
 type DecodedToken = {
 	uid: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export {
 	extractOobCodeFromUrl,
 	firebaseAuthClientPlugin,
-} from "./firebase-auth-client-plugin";
-export { firebaseAuthPlugin } from "./firebase-auth-plugin";
-export type * from "./types";
+} from "./firebase-auth-client-plugin.js";
+export { firebaseAuthPlugin } from "./firebase-auth-plugin.js";
+export type * from "./types.js";

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -4,9 +4,9 @@
     "outDir": "dist",
     "declaration": true,
     "emitDeclarationOnly": false,
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ES2020",
-    "moduleResolution": "Bundler",
+    "moduleResolution": "NodeNext",
     "rootDir": "src",
     "noEmit": false
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
The published package has two independent entry-point defects, both verified against the npm tarball for 2.1.5. Neither is caught by CI, which builds and tests `src/` but never exercises the packed artifact — so both shipped green across all 14 releases.

## Bug 1 — root ESM entry fails in plain Node

`tsconfig.build.json` used `moduleResolution: "Bundler"`, so `tsc` preserved extensionless relative specifiers in the emitted output:

```js
export { extractOobCodeFromUrl, firebaseAuthClientPlugin, } from "./firebase-auth-client-plugin";
```

The package is `"type": "module"` and Node ESM requires explicit `.js` extensions, so `import("better-auth-firebase-auth")` threw `ERR_MODULE_NOT_FOUND`. Only the root `.` entry broke — `/server` and `/client` survived because their only relative imports are type-only and get erased. README documents the root import.

The same defect broke **types** for consumers on `moduleResolution: node16`/`nodenext`: all four `dist/*.d.ts` hit TS2835, so under `skipLibCheck: true` the re-exported types silently vanished and consumers got TS2305/TS2724 for `FirebaseAuthPluginOptions`, `AuthResponse`, `SignInWithGoogleRequest`, `ConfirmPasswordResetRequest` and `VerifyPasswordResetCodeResponse`. Reproduced identically on TS 5.0.4 / 5.9.3 / 6.0.3 / 7.0.2 — not a TS-version issue. `bundler` consumers were unaffected, which is why Next.js users never hit it.

**Fix:** explicit `.js` on the relative imports in `src/`, and both tsconfigs switched to `NodeNext` so the compiler now *enforces* this instead of silently emitting unresolvable specifiers.

## Bug 2 — `dist/index.cjs` was declared but never built

`main` and `exports["."].require` both pointed at `./dist/index.cjs`, but the build is only `tsc` with `module: ESNext`, which emits `.js` exclusively. `require("better-auth-firebase-auth")` failed with `MODULE_NOT_FOUND`.

**Fix: ship ESM-only** rather than adding a CJS build. Two findings made this the clear call:

- **No published version ever contained a `.cjs`** — I downloaded and inspected all 14 tarballs (2.0.0 → 2.1.5); every one has zero `.cjs` files. `require` has never worked, so no consumer can depend on it.
- **`better-auth` is itself ESM-only** (`"type": "module"`, root export is only `default: ./dist/index.mjs`, no `require` condition). A CJS build of a better-auth plugin would serve nobody.

One refinement worth flagging for review: rather than simply deleting the `require` condition, this uses **`default` instead of `import`**, mirroring better-auth's own packaging. Dropping `require` outright would make `require()` fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`; with `default` it resolves through Node's `require(esm)` on Node >= 22.12 and actually works. Applied to `/server` and `/client` too, so the subpaths stay consistent with the root. `main` now points at `./dist/index.js` — a file that exists — rather than being removed.

## Verification

Every check run against a freshly packed tarball installed into a scratch consumer with real peer deps, before and after:

| Check | Before | After |
|---|---|---|
| ESM `import` (root) | `ERR_MODULE_NOT_FOUND` | OK, 3 exports |
| CJS `require` (root) | `MODULE_NOT_FOUND` | OK, 3 exports |
| `/server`, `/client` | OK | OK |
| Types across {5.0.4, 5.9.3, 6.0.3, 7.0.2} x {nodenext, bundler} | 4/8 fail | **8/8 pass** |
| `dist/*.d.ts` under `skipLibCheck: false` | 5 errors | **0 errors** |

Local suite: lint, format, build all pass; 66/66 tests.

## Notes for the reviewer

- Committed as `fix(build):` so semantic-release cuts a **patch**.
- Technically a breaking change for CJS consumers — but since `require` never resolved in any published version, there are none. In practice `require()` gets *better*: it now works on Node >= 22.12.
- `engines.node` left at `>=22`. The ESM path works on all of 22.x; only `require()` needs 22.12+, and restricting installs for ESM consumers (the documented audience) to fix a path that never worked seemed wrong. Happy to bump if you'd rather.
- **CI still never packs the tarball** — the gap that let both bugs ship is untouched here. Worth a follow-up smoke test that packs, installs, and imports.
- Unrelated pre-existing issue spotted: `tsconfig.json` is run by no script and already fails to typecheck (17 errors in `examples/` — missing `jsx` flag and path aliases). Left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)