### PR TITLE
ci: verify the packed artifact on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # The unit tests run against src/, so nothing above this point exercises
+      # what npm actually publishes. Packs the tarball, installs it into a
+      # throwaway consumer, and checks every entry point resolves and types.
+      - name: Verify packed artifact
+        run: ./scripts/verify-pack.sh
+
   compat:
     name: Test against better-auth ${{ matrix.better-auth }}
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,21 @@ pnpm lint:fix
    pnpm lint
    ```
 
-7. Commit your changes with a descriptive message following Conventional Commits format:
+7. If you touched packaging -- `package.json` (`exports`, `main`, `types`),
+   `tsconfig.build.json`, or the files behind an entry point -- verify the
+   published artifact:
+   ```bash
+   pnpm verify:pack
+   ```
+
+   The unit tests import from `src/`, so they cannot catch a broken `exports`
+   map or an unresolvable specifier in `dist/`. This packs the tarball,
+   installs it into a throwaway consumer next to the peer deps, and checks
+   that every entry point resolves from ESM and CJS and still carries its
+   types under both `nodenext` and `bundler` module resolution. CI runs it on
+   every pull request.
+
+8. Commit your changes with a descriptive message following Conventional Commits format:
    ```bash
    # For new features
    feat(firebase-auth): add phone number authentication support
@@ -137,14 +151,14 @@ pnpm lint:fix
    for `fix(deps):` or `fix(security):` when a change genuinely needs to be
    published.
 
-8. Push your branch to your fork
+9. Push your branch to your fork
 
-9. Open a pull request against the **main** branch. In your PR description:
-   - Clearly describe what changes you made and why
-   - Include any relevant context or background
-   - List any breaking changes or deprecations
-   - Reference related issues or discussions
-   - Include examples if adding new features
+10. Open a pull request against the **main** branch. In your PR description:
+    - Clearly describe what changes you made and why
+    - Include any relevant context or background
+    - List any breaking changes or deprecations
+    - Reference related issues or discussions
+    - Include examples if adding new features
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "lint": "biome check --formatter-enabled=false",
     "lint:fix": "biome check --write",
     "lint:fix:unsafe": "biome check --write --unsafe",
+    "verify:pack": "./scripts/verify-pack.sh",
     "prepublishOnly": "pnpm run build"
   },
   "engines": {

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -76,8 +76,12 @@ cat > "$CONSUMER/package.json" <<EOF
 }
 EOF
 
+# pnpm, not npm: the store is already warm from the install earlier in the job,
+# so the peers come from hard links instead of a ~270MB download. Its default
+# isolated layout is also stricter than npm's hoisting -- a dependency the
+# package failed to declare fails here rather than resolving by accident.
 echo "==> installing the tarball next to ${PEERS[*]}"
-(cd "$CONSUMER" && npm install --no-audit --no-fund --ignore-scripts --loglevel=error "$TARBALL")
+(cd "$CONSUMER" && pnpm add --ignore-workspace --ignore-scripts --reporter=silent "$TARBALL")
 
 cat > "$CONSUMER/esm-smoke.mjs" <<'EOF'
 const entries = [

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# Packaging smoke test.
+#
+# The unit tests import from src/, so nothing exercises what npm actually
+# publishes. This packs the tarball, installs it into a throwaway consumer
+# alongside the peer deps, and asserts that every published entry point
+# resolves at runtime and keeps its types.
+#
+# Requires `pnpm build` to have run first. Run locally with `pnpm verify:pack`.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PKG_NAME="better-auth-firebase-auth"
+PEERS=("better-auth" "firebase" "firebase-admin")
+
+actual_name="$(cd "$REPO_ROOT" && node -p 'require("./package.json").name')"
+if [[ "$actual_name" != "$PKG_NAME" ]]; then
+	echo "error: package is now named '$actual_name'; update the fixtures in $0" >&2
+	exit 1
+fi
+
+if [[ ! -f "$REPO_ROOT/dist/index.js" ]]; then
+	echo "error: dist/ is missing or incomplete. Run \`pnpm build\` first." >&2
+	exit 1
+fi
+
+TSC="$REPO_ROOT/node_modules/typescript/bin/tsc"
+if [[ ! -f "$TSC" ]]; then
+	echo "error: typescript not found at $TSC. Run \`pnpm install\` first." >&2
+	exit 1
+fi
+
+# Outside the repo on purpose: inside it, the pnpm workspace root would capture
+# the consumer install.
+WORK="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/pack-smoke.XXXXXX")"
+if [[ -n "${PACK_SMOKE_KEEP:-}" ]]; then
+	echo "note: keeping $WORK (PACK_SMOKE_KEEP is set)"
+else
+	trap 'rm -rf "$WORK"' EXIT
+fi
+
+CONSUMER="$WORK/consumer"
+mkdir -p "$CONSUMER"
+
+echo "==> npm pack"
+(cd "$REPO_ROOT" && npm pack --silent --pack-destination "$WORK" >/dev/null)
+TARBALL="$(find "$WORK" -maxdepth 1 -name '*.tgz' -print -quit)"
+if [[ -z "$TARBALL" ]]; then
+	echo "error: npm pack produced no tarball" >&2
+	exit 1
+fi
+echo "    $(basename "$TARBALL")"
+
+# Pin the peers to the ranges the test suite already runs against, so this
+# never drifts from package.json.
+PEER_DEPS="$(cd "$REPO_ROOT" && node -p '
+	const dev = require("./package.json").devDependencies ?? {};
+	const peers = process.argv.slice(1);
+	const missing = peers.filter((name) => !dev[name]);
+	if (missing.length > 0) {
+		console.error(`error: no devDependency range for ${missing.join(", ")}`);
+		process.exit(1);
+	}
+	JSON.stringify(Object.fromEntries(peers.map((name) => [name, dev[name]])), null, 2);
+' "${PEERS[@]}")"
+
+cat > "$CONSUMER/package.json" <<EOF
+{
+  "name": "pack-smoke-consumer",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": $PEER_DEPS
+}
+EOF
+
+echo "==> installing the tarball next to ${PEERS[*]}"
+(cd "$CONSUMER" && npm install --no-audit --no-fund --ignore-scripts --loglevel=error "$TARBALL")
+
+cat > "$CONSUMER/esm-smoke.mjs" <<'EOF'
+const entries = [
+	[
+		"better-auth-firebase-auth",
+		["firebaseAuthPlugin", "firebaseAuthClientPlugin", "extractOobCodeFromUrl"],
+	],
+	["better-auth-firebase-auth/server", ["firebaseAuthPlugin"]],
+	[
+		"better-auth-firebase-auth/client",
+		["firebaseAuthClientPlugin", "extractOobCodeFromUrl"],
+	],
+];
+
+for (const [specifier, expected] of entries) {
+	const mod = await import(specifier);
+	const missing = expected.filter((name) => typeof mod[name] !== "function");
+	if (missing.length > 0) {
+		throw new Error(`import("${specifier}") is missing: ${missing.join(", ")}`);
+	}
+	console.log(`    ok  import("${specifier}")`);
+}
+EOF
+
+cat > "$CONSUMER/cjs-smoke.cjs" <<'EOF'
+// The package is ESM-only, so this leans on Node's require(esm) support (>= 22.12).
+const mod = require("better-auth-firebase-auth");
+const expected = [
+	"firebaseAuthPlugin",
+	"firebaseAuthClientPlugin",
+	"extractOobCodeFromUrl",
+];
+const missing = expected.filter((name) => typeof mod[name] !== "function");
+if (missing.length > 0) {
+	throw new Error(`require("better-auth-firebase-auth") is missing: ${missing.join(", ")}`);
+}
+console.log('    ok  require("better-auth-firebase-auth")');
+EOF
+
+cat > "$CONSUMER/consumer.ts" <<'EOF'
+import {
+	extractOobCodeFromUrl,
+	firebaseAuthClientPlugin,
+	firebaseAuthPlugin,
+} from "better-auth-firebase-auth";
+import type {
+	AuthResponse,
+	ConfirmPasswordResetRequest,
+	FirebaseAuthPluginOptions,
+	SignInWithGoogleRequest,
+	VerifyPasswordResetCodeResponse,
+} from "better-auth-firebase-auth";
+
+const options: FirebaseAuthPluginOptions = {
+	serverSideOnly: true,
+	sessionExpiresInDays: 7,
+	passwordResetUrl: "https://example.test/reset",
+};
+
+export const pluginId: string = firebaseAuthPlugin(options).id;
+export const clientPlugin = firebaseAuthClientPlugin(options);
+export const oobCode: string | null = extractOobCodeFromUrl(
+	"https://example.test/reset?oobCode=abc",
+);
+
+export const googleRequest: SignInWithGoogleRequest = { idToken: "id-token" };
+export const confirmReset: ConfirmPasswordResetRequest = {
+	oobCode: "abc",
+	newPassword: "hunter2",
+};
+export const verifyResponse: VerifyPasswordResetCodeResponse = {
+	valid: true,
+	email: "user@example.test",
+};
+export const authResponse: AuthResponse = {
+	user: { id: "u1", email: null, name: null, image: null },
+	session: { id: "s1", expiresAt: new Date(), token: "t" },
+};
+
+// If the published declarations degrade to `any` -- which is how the nodenext
+// breakage showed up -- these stop erroring, and tsc then reports the
+// directives themselves as unused, failing the check.
+// @ts-expect-error sessionExpiresInDays is a number, not a string.
+export const badOptions: FirebaseAuthPluginOptions = { sessionExpiresInDays: "7" };
+// @ts-expect-error valid is a boolean, not a string.
+export const badResponse: VerifyPasswordResetCodeResponse = { valid: "yes", email: "" };
+EOF
+
+write_tsconfig() {
+	cat > "$CONSUMER/tsconfig.$1.json" <<EOF
+{
+  "compilerOptions": {
+    "module": "$2",
+    "moduleResolution": "$1",
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": []
+  },
+  "files": ["consumer.ts"]
+}
+EOF
+}
+write_tsconfig nodenext nodenext
+write_tsconfig bundler preserve
+
+echo "==> resolving entry points"
+(cd "$CONSUMER" && node ./esm-smoke.mjs && node ./cjs-smoke.cjs)
+
+echo "==> type-checking a consumer"
+for resolution in nodenext bundler; do
+	(cd "$CONSUMER" && node "$TSC" -p "tsconfig.$resolution.json")
+	echo "    ok  moduleResolution: \"$resolution\""
+done
+
+echo "==> packaging smoke test passed"


### PR DESCRIPTION
> **Stacked on #45** (`fix/better-auth-1-7-account-identity`). Review the top two commits — the four `fix:` commits below them belong to #45. GitHub will retarget this to `main` automatically once #45 lands.

## What

Adds `scripts/verify-pack.sh` and runs it as the last step of the existing `checks` job, so every PR exercises the artifact npm actually publishes.

The script:

1. `npm pack`
2. `npm install`s the tarball into a throwaway consumer in `$RUNNER_TEMP` — outside the repo, so the pnpm workspace root can't capture it — alongside `better-auth`, `firebase`, and `firebase-admin`
3. asserts that `import()` of the root, `/server`, and `/client` entries **and** `require()` of the root all resolve and expose the expected functions
4. type-checks a consumer importing the root entry plus `FirebaseAuthPluginOptions`, `AuthResponse`, `SignInWithGoogleRequest`, `ConfirmPasswordResetRequest`, and `VerifyPasswordResetCodeResponse` under **both** `moduleResolution: "nodenext"` and `"bundler"`

Also exposed as `pnpm verify:pack` for local runs, and documented as a step in CONTRIBUTING for anyone touching packaging.

## Why

The test suite imports from `src/`, so nothing in the pipeline ever touched the packed tarball. Two entry-point defects shipped through a fully green CI in **every release 2.0.0 through 2.1.5**:

- `dist/index.js` re-exported extensionless relative specifiers, so `import("better-auth-firebase-auth")` threw `ERR_MODULE_NOT_FOUND` in plain Node.
- `package.json` pointed `main` and `exports["."].require` at `./dist/index.cjs`, a file no build step ever produced.

Both are fixed by the two `fix(build):` commits now carried in #45. This closes the gap that let them ship in the first place.

The `nodenext` half of the type check is the important one: it is what silently erased every exported type, while `bundler` stayed green — which is why Next.js users never reported it.

## Verification

Run against each state rather than assumed:

| Scenario | Result |
| --- | --- |
| `main` (both defects present) | fails — `ERR_MODULE_NOT_FOUND` on `dist/firebase-auth-client-plugin` |
| Phantom `index.cjs` alone, re-introduced on a fixed tree | fails — `MODULE_NOT_FOUND` on `dist/index.cjs`, exit 1 |
| This branch, rebased onto #45 | passes — all six assertions, exit 0 |

The `nodenext` type check on `main` reproduces the erasure exactly: `TS2305`/`TS2724` for all five types, while `bundler` passes clean.

Full local run on the rebased branch: `lint` 0, `build` 0, `test` 70 passed, `verify:pack` 0 — against better-auth 1.7.1, firebase-admin 14.3.0, and the widened `typescript >=5.0.0` peer from #45.

## Notes for the reviewer

- **Why stacked rather than targeting `main`:** the defects this gate catches are still on `main`, so merging it there first would immediately redden `main`. Stacking makes that ordering impossible to get wrong. It also resolves the `.github/workflows/ci.yml` conflict once — #45 appends a `compat` job at the same spot this step goes. Resolution puts `Verify packed artifact` at the end of `checks`, with `compat` (which `needs: checks`) following it.
- **No effect on the release.** This is `chore(ci):`, and `.releaserc.json` runs the plain angular preset with no custom `releaseRules`, so it publishes nothing. #45's four `fix:` commits produce one release either way.
- Peer versions are read from the repo's own `devDependencies` ranges, so they cannot drift from what the test suite runs against — it picked up better-auth 1.7.1 and firebase-admin 14.3.0 from #45 with no edit.
- The consumer fixture carries two `@ts-expect-error` traps. If the published declarations ever degrade to `any` instead of disappearing outright, the directives go unused and `TS2578` fails the check.
- `require()` of an ESM-only package relies on Node's `require(esm)` support (>= 22.12). Confirmed working on Node 24 with `better-auth` and `firebase-admin` in the graph — no top-level-await problem.
- Cost is roughly 30s cold, 12s warm. Placed after `Test` rather than immediately after `Build` so the cheaper checks fail first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)