### PR TITLE
chore(deps): drop unused better-sqlite3 devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
     "better-auth": "^1.7.1",
-    "better-sqlite3": "^12.9.0",
     "firebase": "^12.12.0",
     "firebase-admin": "^14.3.0",
     "rimraf": "^6.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,9 +52,6 @@ importers:
       better-auth:
         specifier: ^1.7.1
         version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.0)(vite@7.3.6(@types/node@26.1.0)(lightningcss@1.32.0)))
-      better-sqlite3:
-        specifier: ^12.9.0
-        version: 12.11.1
       firebase:
         specifier: ^12.12.0
         version: 12.16.0
@@ -6485,18 +6482,21 @@ snapshots:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
+    optional: true
 
   bignumber.js@9.3.1: {}
 
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
+    optional: true
 
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   bottleneck@2.19.5: {}
 
@@ -6525,6 +6525,7 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+    optional: true
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6564,7 +6565,8 @@ snapshots:
 
   char-regex@1.0.2: {}
 
-  chownr@1.1.4: {}
+  chownr@1.1.4:
+    optional: true
 
   clean-stack@2.2.0: {}
 
@@ -6715,6 +6717,7 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
+    optional: true
 
   deep-extend@0.6.0: {}
 
@@ -6737,7 +6740,8 @@ snapshots:
   delayed-stream@1.0.0:
     optional: true
 
-  detect-libc@2.1.2: {}
+  detect-libc@2.1.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -6789,6 +6793,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   env-ci@11.2.0:
     dependencies:
@@ -7190,7 +7195,8 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  expand-template@2.0.3: {}
+  expand-template@2.0.3:
+    optional: true
 
   expect-type@1.4.0: {}
 
@@ -7255,7 +7261,8 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-uri-to-path@1.0.0: {}
+  file-uri-to-path@1.0.0:
+    optional: true
 
   fill-range@7.1.1:
     dependencies:
@@ -7358,7 +7365,8 @@ snapshots:
     dependencies:
       fetch-blob: 3.2.0
 
-  fs-constants@1.0.0: {}
+  fs-constants@1.0.0:
+    optional: true
 
   fs-extra@11.3.4:
     dependencies:
@@ -7501,7 +7509,8 @@ snapshots:
       through2: 2.0.5
       traverse: 0.6.8
 
-  github-from-package@0.0.0: {}
+  github-from-package@0.0.0:
+    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -7730,7 +7739,8 @@ snapshots:
 
   idb@7.1.1: {}
 
-  ieee754@1.2.1: {}
+  ieee754@1.2.1:
+    optional: true
 
   ignore@5.3.2: {}
 
@@ -8206,7 +8216,8 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  mimic-response@3.1.0: {}
+  mimic-response@3.1.0:
+    optional: true
 
   minimatch@10.2.5:
     dependencies:
@@ -8225,7 +8236,8 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3: {}
+  mkdirp-classic@0.5.3:
+    optional: true
 
   mongodb-connection-string-url@7.0.1:
     dependencies:
@@ -8252,7 +8264,8 @@ snapshots:
 
   nanostores@1.4.0: {}
 
-  napi-build-utils@2.0.0: {}
+  napi-build-utils@2.0.0:
+    optional: true
 
   napi-postinstall@0.3.4: {}
 
@@ -8318,6 +8331,7 @@ snapshots:
   node-abi@3.94.0:
     dependencies:
       semver: 7.8.5
+    optional: true
 
   node-domexception@1.0.0: {}
 
@@ -8423,6 +8437,7 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
   onetime@6.0.0:
     dependencies:
@@ -8580,6 +8595,7 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
+    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -8622,6 +8638,7 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
+    optional: true
 
   punycode@2.3.1: {}
 
@@ -8688,6 +8705,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -9004,13 +9022,15 @@ snapshots:
       figures: 2.0.0
       pkg-conf: 2.1.0
 
-  simple-concat@1.0.1: {}
+  simple-concat@1.0.1:
+    optional: true
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+    optional: true
 
   skin-tone@2.0.0:
     dependencies:
@@ -9146,6 +9166,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -9207,6 +9228,7 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
+    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -9215,6 +9237,7 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
+    optional: true
 
   teeny-request@10.1.4:
     dependencies:
@@ -9305,6 +9328,7 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   tunnel@0.0.6: {}
 
@@ -9643,7 +9667,8 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   xml-naming@0.3.0:
     optional: true


### PR DESCRIPTION
> **Stacked on #45** (`fix/better-auth-1-7-account-identity`), not `main`.
> Both rewrite `package.json` and `pnpm-lock.yaml`, and a three-way merge of the
> two against `main` conflicts in **both** files:
> ```
> CONFLICT (content): Merge conflict in package.json
> CONFLICT (content): Merge conflict in pnpm-lock.yaml
> ```
> Basing this on #45 resolves that once, here, instead of leaving it for
> whichever landed second. Merge #45 first; this then applies cleanly.

`better-sqlite3` was never imported. Across the whole repo it appeared exactly
twice — the devDependency line and the `allowBuilds` entry. It arrived in
`6bec7d4` alongside the better-auth 1.5.x adapter work, but no test ever used
it; the suite mocks `internalAdapter` instead.

**Does not publish** — `chore(deps)` is inert since #47.

## Why it was actively harmful

better-auth pins the peer at `^12.0.0` on **both** 1.6.23 and 1.7.1. Meanwhile
Dependabot manages the *direct devDependency* against the registry, and has now
twice proposed a major bump better-auth does not accept:

| PR | date | proposed |
| --- | --- | --- |
| #41 (closed) | 13 Aug 2026 | `13.0.1` |
| #46 (open) | 23 Aug 2026 | `13.0.3` |

Both carry identical metadata — `dependency-type: direct:development`,
`update-type: version-update:semver-major`, `dependency-group: dev-dependencies`.
The `dev-dependencies` group is `patterns: ["*"]` with no `update-types` filter,
so majors are in scope.

Nothing caught it: Dependabot resolves against this manifest and cannot see
another package's peer range, and pnpm treats the unmet peer as a warning rather
than an error, so CI stayed green while the two drifted apart.

```
✕ unmet peer better-sqlite3
  Installed: 13.0.3
  Wanted:  ^12.0.0  <- better-auth
```

## Why removing the declaration is safe

It does not remove the package. better-auth declares `better-sqlite3` as a peer
and pnpm auto-installs peers by default, so it still resolves — now to whatever
better-auth actually asks for:

```
better-sqlite3@12.11.1
└─┬ better-auth peer
```

The peer ends up satisfied instead of violated, the version tracks better-auth
automatically if they widen the range, and there is no longer a direct
dependency for Dependabot to re-propose every Monday.

The `allowBuilds: better-sqlite3: true` entry in
[pnpm-workspace.yaml](pnpm-workspace.yaml) is **deliberately retained** — the
auto-installed copy still carries a native build script, and dropping it fails
the install with `ERR_PNPM_IGNORED_BUILDS`.

## Verification

Run on top of #45, so this also confirms the removal holds against better-auth
1.7.1:

- `pnpm install` and `pnpm install --frozen-lockfile` — clean
- `pnpm lint` / `pnpm build` — pass
- `pnpm test` — 70/70
- `pnpm audit --audit-level=moderate` — no known vulnerabilities
- `pnpm verify:pack` — packaging smoke test passed (#45's own verifier)
- `pnpm peers check` — better-sqlite3 peer satisfied, resolves to `12.11.1`

## Follow-on

Once #45 and this land, `@dependabot rebase` on #46 regenerates the group
**without** the better-sqlite3 entry, since there will no longer be a direct
dependency to bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
