### PR TITLE
fix(server): adapter-based 1.7 issuer backfill + orphaned-account re-parenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,15 +350,30 @@ One build of the plugin supports every Better Auth release since 1.5. The plugin
 Better Auth 1.7 adds a required `issuer` column to the `account` table and looks accounts up by `(issuer, accountId)` — there is no fallback to `providerId`. `npx auth migrate` refuses to add a `NOT NULL` column to a populated table, so every existing install needs a one-time backfill. This is part of the [Better Auth 1.7 upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer); the plugin-specific part is the value to use for Firebase rows:
 
 1. Add `issuer` to `account` as a **nullable** column.
-2. Backfill Firebase-linked rows (and any other providers you use, per the upgrade guide):
+2. Backfill Firebase-linked rows (and any other providers you use, per the upgrade guide) — either way works:
+
+   **No SQL — through your configured adapter** (any database Better Auth supports, honors custom model/field names). Run once from a one-off script, seed file, or admin route:
+
+   ```ts
+   import { auth } from "./lib/auth"; // your betterAuth(...) instance
+   import { backfillAccountIssuers } from "better-auth-firebase-auth/server";
+
+   const { total, updated } = await backfillAccountIssuers(auth);
+   console.log(`stamped ${updated}/${total} firebase account rows`);
+   // pass { dryRun: true } to count without writing
+   ```
+
+   **Or plain SQL**, run in the database that backs Better Auth (`psql`, `mysql`, `sqlite3`, or a migration file in your ORM — the plugin has no database access of its own, so there is no `npx` command):
 
    ```sql
    UPDATE account SET issuer = 'local:oauth:firebase' WHERE "providerId" = 'firebase';
    ```
 
+   The statement is Postgres-flavored — camelCase identifiers need the double quotes. MySQL uses backticks (`` `providerId` ``), and if you map Better Auth to snake_case the column is `provider_id`. Both forms are idempotent, and both repair rows a MySQL `auth migrate` corrupted to an empty string.
+
 3. Make `issuer` `NOT NULL` and add the unique `(issuer, accountId)` index (`npx auth migrate` / `npx auth generate` can do this step once no row is empty).
 
-The value is exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server` for use in migration scripts. New rows written on Better Auth 1.7 already carry it.
+The issuer value is exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server` for use in migration scripts. New rows written on Better Auth 1.7 already carry it.
 
 If the backfill is skipped, sign-in still works: the plugin falls back to matching by email and links a fresh account row — but the old row is left orphaned and, on MySQL, `auth migrate` may have silently filled `issuer` with an empty string (see the upgrade guide's corruption check).
 

--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ firebaseAuthPlugin({
 | `sessionExpiresInDays` | `number` | `7` | Better Auth session lifetime. |
 | `passwordResetUrl` | `string` | — | Custom URL Firebase appends the reset code to. |
 | `getPhoneUserFallbackEmail` | `({ uid, phoneNumber }) => string` | `${uid}@firebase.local` | Generate a stable synthetic email for phone-only users. |
+| `migrationChecks` | `boolean` | `true` | Warn at startup while Firebase account rows still lack the Better Auth 1.7 `issuer` (two `count` reads per process; skipped on Better Auth < 1.7). |
 
 ---
 
@@ -375,7 +376,7 @@ Better Auth 1.7 adds a required `issuer` column to the `account` table and looks
 
 The issuer value is exported as `FIREBASE_ACCOUNT_ISSUER` from `better-auth-firebase-auth/server` for use in migration scripts. New rows written on Better Auth 1.7 already carry it.
 
-If the backfill is skipped, sign-in still works: the plugin falls back to matching by email and links a fresh account row — but the old row is left orphaned and, on MySQL, `auth migrate` may have silently filled `issuer` with an empty string (see the upgrade guide's corruption check).
+**If you forget:** the plugin checks on startup and logs one `[better-auth-firebase-auth]` warning with the exact command whenever Better Auth expects `issuer` but Firebase account rows lack it (two `count` reads per process; `migrationChecks: false` disables it). Sign-in itself keeps working — the plugin falls back to matching by email and re-links — but until the backfill runs the old row stays orphaned and, on MySQL, `auth migrate` may have silently filled `issuer` with an empty string (see the upgrade guide's corruption check).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -351,26 +351,34 @@ One build of the plugin supports every Better Auth release since 1.5. The plugin
 Better Auth 1.7 adds a required `issuer` column to the `account` table and looks accounts up by `(issuer, accountId)` — there is no fallback to `providerId`. `npx auth migrate` refuses to add a `NOT NULL` column to a populated table, so every existing install needs a one-time backfill. This is part of the [Better Auth 1.7 upgrade guide](https://better-auth.com/docs/guides/1-7-upgrade-guide#account-identity-is-scoped-by-issuer); the plugin-specific part is the value to use for Firebase rows:
 
 1. Add `issuer` to `account` as a **nullable** column.
-2. Backfill Firebase-linked rows (and any other providers you use, per the upgrade guide) — either way works:
+2. Backfill Firebase-linked rows (and any other providers you use, per the upgrade guide) — three equivalent ways, all idempotent, all repairing rows a MySQL `auth migrate` corrupted to an empty string:
 
-   **No SQL — through your configured adapter** (any database Better Auth supports, honors custom model/field names). Run once from a one-off script, seed file, or admin route:
+   **CLI** — like `npx auth migrate`, it finds and imports the file exporting your `betterAuth(...)` instance and runs the backfill through its database adapter (the plugin holds no database credentials of its own):
+
+   ```bash
+   npx better-auth-firebase-auth backfill-account-issuers            # dry run: prints the report, writes nothing
+   npx better-auth-firebase-auth backfill-account-issuers --apply    # writes, with authentication writes paused
+   ```
+
+   Pass `--config path/to/auth.ts` if your config lives somewhere unusual. The config is imported with `jiti` when your project has it (Better Auth's own CLI ships it), otherwise with Node's native TypeScript support (Node ≥ 22.18); `--help` lists everything.
+
+   **Programmatically** — same engine, from a one-off script, seed file, or admin route:
 
    ```ts
    import { auth } from "./lib/auth"; // your betterAuth(...) instance
    import { backfillAccountIssuers } from "better-auth-firebase-auth/server";
 
-   const { total, updated } = await backfillAccountIssuers(auth);
-   console.log(`stamped ${updated}/${total} firebase account rows`);
+   const { total, missing, updated } = await backfillAccountIssuers(auth);
    // pass { dryRun: true } to count without writing
    ```
 
-   **Or plain SQL**, run in the database that backs Better Auth (`psql`, `mysql`, `sqlite3`, or a migration file in your ORM — the plugin has no database access of its own, so there is no `npx` command):
+   **Or plain SQL**, run in the database that backs Better Auth (`psql`, `mysql`, `sqlite3`, or a migration file in your ORM):
 
    ```sql
    UPDATE account SET issuer = 'local:oauth:firebase' WHERE "providerId" = 'firebase';
    ```
 
-   The statement is Postgres-flavored — camelCase identifiers need the double quotes. MySQL uses backticks (`` `providerId` ``), and if you map Better Auth to snake_case the column is `provider_id`. Both forms are idempotent, and both repair rows a MySQL `auth migrate` corrupted to an empty string.
+   The statement is Postgres-flavored — camelCase identifiers need the double quotes. MySQL uses backticks (`` `providerId` ``), and if you map Better Auth to snake_case the column is `provider_id`.
 
 3. Make `issuer` `NOT NULL` and add the unique `(issuer, accountId)` index (`npx auth migrate` / `npx auth generate` can do this step once no row is empty).
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "author": "Slava Yultyyev <yultyyev@gmail.com>",
   "license": "MIT",
   "type": "module",
+  "bin": {
+    "better-auth-firebase-auth": "./dist/cli.js"
+  },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -79,6 +82,7 @@
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",
     "@semantic-release/release-notes-generator": "^14.1.0",
+    "@types/node": "^24.13.3",
     "better-auth": "^1.7.1",
     "firebase": "^12.12.0",
     "firebase-admin": "^14.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@semantic-release/release-notes-generator':
         specifier: ^14.1.0
         version: 14.1.1(semantic-release@25.0.9(typescript@7.0.2))
+      '@types/node':
+        specifier: ^24
+        version: 24.13.3
       better-auth:
         specifier: ^1.7.1
         version: 1.7.1(@opentelemetry/api@1.9.1)(better-sqlite3@12.11.1)(mongodb@7.1.0)(next@16.3.2(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(react-dom@19.2.8(react@19.2.7))(react@19.2.7))(react-dom@19.2.8(react@19.2.7))(react@19.2.7)(vitest@4.1.11(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(vite@7.3.6(@types/node@24.13.3)(lightningcss@1.32.0)))
@@ -1986,6 +1989,7 @@ packages:
   'better-auth-firebase-auth@file:':
     resolution: {directory: '', type: directory}
     engines: {node: '>=22'}
+    hasBin: true
     peerDependencies:
       better-auth: '>=1.5.0'
       firebase: '>=9'

--- a/scripts/verify-pack.sh
+++ b/scripts/verify-pack.sh
@@ -221,4 +221,34 @@ for check in "${CHECKS[@]}"; do
 	echo "    ok  moduleResolution: \"$resolution\", module: \"$mod\""
 done
 
+echo "==> running the installed bin"
+BIN="$CONSUMER/node_modules/.bin/better-auth-firebase-auth"
+if [[ ! -x "$BIN" ]]; then
+	echo "error: installed package exposes no better-auth-firebase-auth bin" >&2
+	exit 1
+fi
+"$BIN" --help >/dev/null
+echo "    ok  --help"
+
+# Functional dry run against a throwaway Better Auth instance (memory adapter):
+# proves config discovery, instance detection, and the adapter round trip from
+# the packed artifact.
+cat > "$CONSUMER/auth.mjs" <<'AUTHEOF'
+import { betterAuth } from "better-auth";
+import { memoryAdapter } from "better-auth/adapters/memory";
+export const auth = betterAuth({
+	database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+	secret: "verify-pack-secret-verify-pack-secret",
+	baseURL: "http://localhost:3000",
+	logger: { level: "error" },
+});
+AUTHEOF
+BACKFILL_OUT="$(cd "$CONSUMER" && "$BIN" backfill-account-issuers --config auth.mjs)"
+if ! grep -q "0 Firebase account row(s)" <<<"$BACKFILL_OUT"; then
+	echo "error: unexpected backfill dry-run output:" >&2
+	echo "$BACKFILL_OUT" >&2
+	exit 1
+fi
+echo "    ok  backfill-account-issuers dry run"
+
 echo "==> packaging smoke test passed"

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,74 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { discoverConfig, parseArgs, resolveAuthExport } from "./cli.js";
+
+describe("cli", () => {
+	describe("parseArgs", () => {
+		it("parses the command with defaults", () => {
+			const args = parseArgs(["backfill-account-issuers"]);
+			expect(args.command).toBe("backfill-account-issuers");
+			expect(args.apply).toBe(false);
+			expect(args.config).toBeNull();
+			expect(args.help).toBe(false);
+		});
+
+		it("parses --apply, --config and --cwd", () => {
+			const args = parseArgs([
+				"backfill-account-issuers",
+				"--apply",
+				"--config",
+				"lib/auth.ts",
+				"--cwd",
+				"/tmp/app",
+			]);
+			expect(args.apply).toBe(true);
+			expect(args.config).toBe("lib/auth.ts");
+			expect(args.cwd).toBe("/tmp/app");
+		});
+
+		it("throws on unknown flags and missing values", () => {
+			expect(() => parseArgs(["--nope"])).toThrow(/Unknown argument/);
+			expect(() => parseArgs(["--config"])).toThrow(/requires a path/);
+			expect(() => parseArgs(["--cwd"])).toThrow(/requires a directory/);
+		});
+	});
+
+	describe("discoverConfig", () => {
+		const dir = mkdtempSync(join(tmpdir(), "bafa-cli-"));
+		afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+		it("returns null when nothing exists", () => {
+			expect(discoverConfig(dir)).toBeNull();
+		});
+
+		it("finds the same locations npx auth searches", () => {
+			mkdirSync(join(dir, "src/lib"), { recursive: true });
+			writeFileSync(join(dir, "src/lib/auth.ts"), "");
+			expect(discoverConfig(dir)).toBe(join(dir, "src/lib/auth.ts"));
+
+			// Root-level config wins over nested ones.
+			writeFileSync(join(dir, "auth.ts"), "");
+			expect(discoverConfig(dir)).toBe(join(dir, "auth.ts"));
+		});
+	});
+
+	describe("resolveAuthExport", () => {
+		const authLike = { $context: Promise.resolve({}) };
+
+		it("prefers the named auth export", () => {
+			expect(resolveAuthExport({ auth: authLike, other: 1 })).toBe(authLike);
+		});
+
+		it("accepts a default export or any auth-shaped export", () => {
+			expect(resolveAuthExport({ default: authLike })).toBe(authLike);
+			expect(resolveAuthExport({ default: { auth: authLike } })).toBe(authLike);
+			expect(resolveAuthExport({ whatever: authLike })).toBe(authLike);
+		});
+
+		it("returns null when nothing looks like a Better Auth instance", () => {
+			expect(resolveAuthExport({ auth: { notIt: true }, x: 3 })).toBeNull();
+		});
+	});
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * `npx better-auth-firebase-auth backfill-account-issuers`
+ *
+ * Runs the Better Auth 1.7 `account.issuer` backfill for Firebase rows through
+ * the database adapter configured on the app's own Better Auth instance. The
+ * plugin never holds database credentials, so — like `npx auth migrate` — the
+ * command locates and imports the app's auth config and uses that instance.
+ *
+ * Dry run by default; `--apply` writes. See `--help`.
+ */
+import { existsSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { backfillAccountIssuers } from "./firebase-auth-plugin.js";
+
+const COMMAND = "backfill-account-issuers";
+
+const HELP = `Usage: better-auth-firebase-auth ${COMMAND} [options]
+
+Stamps issuer = "local:oauth:firebase" on account rows with
+providerId = "firebase" that were written before Better Auth 1.7,
+through the database adapter of your Better Auth instance.
+
+Dry run by default: prints the report and writes nothing.
+
+Options:
+  --apply            Write the backfill (pause authentication writes first)
+  --config <path>    Path to the file exporting your betterAuth(...) instance
+                     (default: searched in the same locations as \`npx auth\`)
+  --cwd <dir>        Directory to search from (default: current directory)
+  -h, --help         Show this help
+
+The config file is imported with jiti when your project has it installed
+(better-auth's own CLI ships it), otherwise with Node's native TypeScript
+type stripping (Node >= 22.18). If both fail, install jiti (npm i -D jiti)
+or point --config at a compiled .js/.mjs module.
+`;
+
+/** Mirrors the config locations \`npx auth\` searches. */
+const buildConfigCandidates = (): string[] => {
+	let paths = [
+		"auth.ts",
+		"auth.tsx",
+		"auth.js",
+		"auth.jsx",
+		"auth.server.js",
+		"auth.server.ts",
+		"auth/index.ts",
+		"auth/index.tsx",
+		"auth/index.js",
+		"auth/index.jsx",
+		"auth/index.server.js",
+		"auth/index.server.ts",
+	];
+	paths = [
+		...paths,
+		...paths.map((it) => `lib/server/${it}`),
+		...paths.map((it) => `server/auth/${it}`),
+		...paths.map((it) => `server/${it}`),
+		...paths.map((it) => `auth/${it}`),
+		...paths.map((it) => `lib/${it}`),
+		...paths.map((it) => `utils/${it}`),
+	];
+	return [
+		...paths,
+		...paths.map((it) => `src/${it}`),
+		...paths.map((it) => `app/${it}`),
+	];
+};
+
+export interface CliArgs {
+	command: string | null;
+	apply: boolean;
+	config: string | null;
+	cwd: string;
+	help: boolean;
+}
+
+export const parseArgs = (argv: string[]): CliArgs => {
+	const args: CliArgs = {
+		command: null,
+		apply: false,
+		config: null,
+		cwd: process.cwd(),
+		help: false,
+	};
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+		} else if (arg === "--apply") {
+			args.apply = true;
+		} else if (arg === "--config") {
+			args.config = argv[++i] ?? null;
+			if (!args.config) throw new Error("--config requires a path");
+		} else if (arg === "--cwd") {
+			const dir = argv[++i];
+			if (!dir) throw new Error("--cwd requires a directory");
+			args.cwd = dir;
+		} else if (!arg.startsWith("-") && args.command === null) {
+			args.command = arg;
+		} else {
+			throw new Error(`Unknown argument: ${arg}`);
+		}
+	}
+	return args;
+};
+
+export const discoverConfig = (cwd: string): string | null => {
+	for (const candidate of buildConfigCandidates()) {
+		const path = resolve(cwd, candidate);
+		if (existsSync(path)) return path;
+	}
+	return null;
+};
+
+const loadEnv = (cwd: string): void => {
+	// First file wins for a given key, matching dotenv: load .env.local first.
+	for (const file of [".env.local", ".env"]) {
+		try {
+			process.loadEnvFile(resolve(cwd, file));
+		} catch {
+			// Missing file (or Node without loadEnvFile) — fine.
+		}
+	}
+};
+
+const loadConfigModule = async (
+	path: string,
+): Promise<Record<string, unknown>> => {
+	let createJiti: ((id: string, opts?: object) => any) | null = null;
+	try {
+		// Not a dependency of this package on purpose — resolved from the app
+		// when present. The indirection keeps tsc from requiring its types.
+		const jitiSpecifier = "jiti";
+		({ createJiti } = await import(jitiSpecifier));
+	} catch {
+		createJiti = null; // jiti not installed — fall back to native import.
+	}
+	if (createJiti) {
+		const jiti = createJiti(import.meta.url, { interopDefault: false });
+		return await jiti.import(path);
+	}
+	try {
+		return await import(pathToFileURL(path).href);
+	} catch (error) {
+		const code = (error as { code?: string }).code;
+		if (code === "ERR_UNKNOWN_FILE_EXTENSION" || error instanceof SyntaxError) {
+			throw new Error(
+				`Could not import ${path} with Node ${process.version} directly. ` +
+					"Native TypeScript imports need Node >= 22.18; install jiti " +
+					"(npm i -D jiti) and re-run, or pass --config with a compiled " +
+					".js/.mjs module.",
+				{ cause: error },
+			);
+		}
+		throw error;
+	}
+};
+
+type AuthLike = Parameters<typeof backfillAccountIssuers>[0];
+
+const looksLikeAuth = (value: unknown): value is AuthLike =>
+	typeof value === "object" &&
+	value !== null &&
+	typeof (value as { $context?: { then?: unknown } }).$context?.then ===
+		"function";
+
+export const resolveAuthExport = (
+	mod: Record<string, unknown>,
+): AuthLike | null => {
+	if (looksLikeAuth(mod.auth)) return mod.auth;
+	if (looksLikeAuth(mod.default)) return mod.default;
+	const nested = (mod.default as Record<string, unknown> | undefined)?.auth;
+	if (looksLikeAuth(nested)) return nested;
+	for (const value of Object.values(mod)) {
+		if (looksLikeAuth(value)) return value;
+	}
+	return null;
+};
+
+const fail = (message: string): never => {
+	console.error(`error: ${message}`);
+	process.exit(1);
+};
+
+export const run = async (argv: string[]): Promise<void> => {
+	let args: CliArgs;
+	try {
+		args = parseArgs(argv);
+	} catch (error) {
+		fail((error as Error).message);
+		return;
+	}
+	if (args.help || args.command === null) {
+		console.log(HELP);
+		process.exit(args.help ? 0 : 1);
+	}
+	if (args.command !== COMMAND) {
+		fail(`Unknown command "${args.command}". Only "${COMMAND}" is available.`);
+	}
+
+	const cwd = resolve(args.cwd);
+	loadEnv(cwd);
+
+	const configPath = args.config
+		? resolve(cwd, args.config)
+		: discoverConfig(cwd);
+	if (!configPath || !existsSync(configPath)) {
+		fail(
+			args.config
+				? `Config not found: ${args.config}`
+				: `No Better Auth config found under ${cwd}. Pass --config <path> ` +
+						"to the file that exports your betterAuth(...) instance.",
+		);
+		return;
+	}
+	console.log(`==> using ${configPath}`);
+
+	const mod = await loadConfigModule(configPath);
+	const auth = resolveAuthExport(mod);
+	if (!auth) {
+		fail(
+			`${configPath} does not export a Better Auth instance. Export it as ` +
+				"`export const auth = betterAuth({ ... })` (or default).",
+		);
+		return;
+	}
+
+	const report = await backfillAccountIssuers(auth, { dryRun: true });
+	console.log(
+		`==> ${report.total} Firebase account row(s); ${report.missing} missing issuer`,
+	);
+
+	if (!args.apply) {
+		console.log(
+			report.missing === 0
+				? "Nothing to do."
+				: `Dry run — nothing written. Re-run with --apply to stamp ${report.missing} row(s).`,
+		);
+		process.exit(0);
+	}
+
+	const result = await backfillAccountIssuers(auth);
+	const after = await backfillAccountIssuers(auth, { dryRun: true });
+	console.log(
+		`==> stamped issuer on ${result.updated} row(s); ${after.missing} still missing`,
+	);
+	process.exit(after.missing === 0 ? 0 : 1);
+};
+
+const isDirectRun = (): boolean => {
+	if (!process.argv[1]) return false;
+	try {
+		// npm/pnpm expose the bin through a symlink; compare real paths.
+		return (
+			realpathSync(process.argv[1]) ===
+			realpathSync(fileURLToPath(import.meta.url))
+		);
+	} catch {
+		return false;
+	}
+};
+
+if (isDirectRun()) {
+	run(process.argv.slice(2)).catch((error) => {
+		console.error(`error: ${(error as Error).message}`);
+		process.exit(1);
+	});
+}

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -1,6 +1,7 @@
 import { setSessionCookie } from "better-auth/cookies";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	backfillAccountIssuers,
 	createOrUpdateUser,
 	FIREBASE_ACCOUNT_ISSUER,
 	firebaseAuthPlugin,
@@ -579,6 +580,64 @@ describe("firebaseAuthPlugin", () => {
 		});
 	});
 
+	// ─── backfillAccountIssuers ──────────────────────────────────────────
+
+	describe("backfillAccountIssuers", () => {
+		const adapter = { count: vi.fn(), updateMany: vi.fn() };
+		const tables = { account: { fields: { issuer: { type: "string" } } } };
+		const auth = { $context: Promise.resolve({ adapter, tables }) } as any;
+
+		beforeEach(() => {
+			adapter.count.mockResolvedValue(3);
+			adapter.updateMany.mockResolvedValue(3);
+		});
+
+		it("should stamp the issuer on all firebase rows through the adapter", async () => {
+			const result = await backfillAccountIssuers(auth);
+
+			expect(adapter.count).toHaveBeenCalledWith({
+				model: "account",
+				where: [{ field: "providerId", value: "firebase" }],
+			});
+			expect(adapter.updateMany).toHaveBeenCalledWith({
+				model: "account",
+				where: [{ field: "providerId", value: "firebase" }],
+				update: { issuer: FIREBASE_ACCOUNT_ISSUER },
+			});
+			expect(result).toEqual({ total: 3, updated: 3 });
+		});
+
+		it("should not write on a dry run", async () => {
+			const result = await backfillAccountIssuers(auth, { dryRun: true });
+
+			expect(adapter.updateMany).not.toHaveBeenCalled();
+			expect(result).toEqual({ total: 3, updated: 0 });
+		});
+
+		it("should not write when there are no firebase rows", async () => {
+			adapter.count.mockResolvedValue(0);
+			const result = await backfillAccountIssuers(auth);
+
+			expect(adapter.updateMany).not.toHaveBeenCalled();
+			expect(result).toEqual({ total: 0, updated: 0 });
+		});
+
+		it("should refuse on Better Auth < 1.7 (no account.issuer field)", async () => {
+			const legacyAuth = {
+				$context: Promise.resolve({
+					adapter,
+					tables: { account: { fields: { providerId: {} } } },
+				}),
+			} as any;
+
+			await expect(backfillAccountIssuers(legacyAuth)).rejects.toThrow(
+				/Better Auth >= 1\.7/,
+			);
+			expect(adapter.count).not.toHaveBeenCalled();
+			expect(adapter.updateMany).not.toHaveBeenCalled();
+		});
+	});
+
 	// ─── Hook Matchers ───────────────────────────────────────────────────
 
 	describe("hook matchers", () => {
@@ -1130,5 +1189,61 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 		});
 		expect(accounts).toHaveLength(1);
 		expect((accounts[0] as any).userId).toBe(secondUserId);
+	});
+
+	it("should backfill issuer on pre-1.7 rows so the account is found again", async () => {
+		const { client, auth } = await getTestInstance(
+			{
+				plugins: [
+					firebaseAuthPlugin({
+						firebaseAdminAuth: mockAdminAuth as any,
+					}),
+				],
+			},
+			{ disableTestUser: true },
+		);
+
+		const res1 = await client.$fetch("/firebase-auth/sign-in-with-google", {
+			method: "POST",
+			body: { idToken: "token-1" },
+		});
+		const userId = (res1.data as any).user.id;
+
+		const ctx = await (auth as any).$context;
+		if (!ctx.tables.account?.fields?.issuer) {
+			// better-auth < 1.7: the schema has no issuer, so the backfill must
+			// refuse rather than silently write nothing.
+			await expect(backfillAccountIssuers(auth as any)).rejects.toThrow(
+				/Better Auth >= 1\.7/,
+			);
+			return;
+		}
+
+		// Simulate a row written before 1.7 (no meaningful issuer).
+		await ctx.adapter.updateMany({
+			model: "account",
+			where: [{ field: "accountId", value: mockDecodedToken.uid }],
+			update: { issuer: "" },
+		});
+
+		const dry = await backfillAccountIssuers(auth as any, { dryRun: true });
+		expect(dry).toEqual({ total: 1, updated: 0 });
+
+		const result = await backfillAccountIssuers(auth as any);
+		expect(result).toEqual({ total: 1, updated: 1 });
+
+		// The stamped row is found by (issuer, accountId) again: same user, no duplicate.
+		const res2 = await client.$fetch("/firebase-auth/sign-in-with-google", {
+			method: "POST",
+			body: { idToken: "token-2" },
+		});
+		expect((res2.data as any).user.id).toBe(userId);
+
+		const accounts = await ctx.adapter.findMany({
+			model: "account",
+			where: [{ field: "accountId", value: mockDecodedToken.uid }],
+		});
+		expect(accounts).toHaveLength(1);
+		expect((accounts[0] as any).issuer).toBe(FIREBASE_ACCOUNT_ISSUER);
 	});
 });

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -638,6 +638,93 @@ describe("firebaseAuthPlugin", () => {
 		});
 	});
 
+	// ─── migrationChecks startup warning ─────────────────────────────────
+
+	describe("migrationChecks startup warning", () => {
+		const makeCtx = (
+			counts: { total: number; stamped: number },
+			hasIssuerField = true,
+		) => {
+			const count = vi
+				.fn()
+				.mockResolvedValueOnce(counts.total)
+				.mockResolvedValueOnce(counts.stamped);
+			return {
+				ctx: {
+					tables: {
+						account: {
+							fields: hasIssuerField ? { issuer: {} } : { providerId: {} },
+						},
+					},
+					adapter: { count },
+					logger: { warn: vi.fn() },
+				},
+				count,
+			};
+		};
+
+		const flush = () => new Promise((r) => setTimeout(r, 0));
+
+		it("should warn with the remediation when firebase rows lack issuer", async () => {
+			const { ctx } = makeCtx({ total: 5, stamped: 2 });
+			const plugin = firebaseAuthPlugin({
+				firebaseAdminAuth: mockAdminAuth as any,
+			});
+			plugin.init?.(ctx as any);
+			await flush();
+
+			expect(ctx.logger.warn).toHaveBeenCalledOnce();
+			const message = ctx.logger.warn.mock.calls[0][0] as string;
+			expect(message).toContain("3 of 5");
+			expect(message).toContain("backfillAccountIssuers");
+			expect(message).toContain(FIREBASE_ACCOUNT_ISSUER);
+			expect(message).toContain("migrationChecks: false");
+		});
+
+		it("should stay silent when every row is stamped", async () => {
+			const { ctx } = makeCtx({ total: 5, stamped: 5 });
+			firebaseAuthPlugin({ firebaseAdminAuth: mockAdminAuth as any }).init?.(
+				ctx as any,
+			);
+			await flush();
+			expect(ctx.logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("should stay silent and read nothing on Better Auth < 1.7", async () => {
+			const { ctx, count } = makeCtx({ total: 5, stamped: 0 }, false);
+			firebaseAuthPlugin({ firebaseAdminAuth: mockAdminAuth as any }).init?.(
+				ctx as any,
+			);
+			await flush();
+			expect(count).not.toHaveBeenCalled();
+			expect(ctx.logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("should not run at all when migrationChecks is false", async () => {
+			const { ctx, count } = makeCtx({ total: 5, stamped: 0 });
+			firebaseAuthPlugin({
+				firebaseAdminAuth: mockAdminAuth as any,
+				migrationChecks: false,
+			}).init?.(ctx as any);
+			await flush();
+			expect(count).not.toHaveBeenCalled();
+			expect(ctx.logger.warn).not.toHaveBeenCalled();
+		});
+
+		it("should never throw when the adapter fails", async () => {
+			const ctx = {
+				tables: { account: { fields: { issuer: {} } } },
+				adapter: { count: vi.fn().mockRejectedValue(new Error("boom")) },
+				logger: { warn: vi.fn() },
+			};
+			firebaseAuthPlugin({ firebaseAdminAuth: mockAdminAuth as any }).init?.(
+				ctx as any,
+			);
+			await flush();
+			expect(ctx.logger.warn).not.toHaveBeenCalled();
+		});
+	});
+
 	// ─── Hook Matchers ───────────────────────────────────────────────────
 
 	describe("hook matchers", () => {

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -588,38 +588,46 @@ describe("firebaseAuthPlugin", () => {
 		const auth = { $context: Promise.resolve({ adapter, tables }) } as any;
 
 		beforeEach(() => {
-			adapter.count.mockResolvedValue(3);
+			// First count: total firebase rows; second: rows already stamped.
+			adapter.count.mockResolvedValueOnce(3).mockResolvedValueOnce(1);
 			adapter.updateMany.mockResolvedValue(3);
 		});
 
 		it("should stamp the issuer on all firebase rows through the adapter", async () => {
 			const result = await backfillAccountIssuers(auth);
 
-			expect(adapter.count).toHaveBeenCalledWith({
+			expect(adapter.count).toHaveBeenNthCalledWith(1, {
 				model: "account",
 				where: [{ field: "providerId", value: "firebase" }],
+			});
+			expect(adapter.count).toHaveBeenNthCalledWith(2, {
+				model: "account",
+				where: [
+					{ field: "providerId", value: "firebase" },
+					{ field: "issuer", value: FIREBASE_ACCOUNT_ISSUER },
+				],
 			});
 			expect(adapter.updateMany).toHaveBeenCalledWith({
 				model: "account",
 				where: [{ field: "providerId", value: "firebase" }],
 				update: { issuer: FIREBASE_ACCOUNT_ISSUER },
 			});
-			expect(result).toEqual({ total: 3, updated: 3 });
+			expect(result).toEqual({ total: 3, missing: 2, updated: 3 });
 		});
 
 		it("should not write on a dry run", async () => {
 			const result = await backfillAccountIssuers(auth, { dryRun: true });
 
 			expect(adapter.updateMany).not.toHaveBeenCalled();
-			expect(result).toEqual({ total: 3, updated: 0 });
+			expect(result).toEqual({ total: 3, missing: 2, updated: 0 });
 		});
 
 		it("should not write when there are no firebase rows", async () => {
-			adapter.count.mockResolvedValue(0);
+			adapter.count.mockReset().mockResolvedValue(0);
 			const result = await backfillAccountIssuers(auth);
 
 			expect(adapter.updateMany).not.toHaveBeenCalled();
-			expect(result).toEqual({ total: 0, updated: 0 });
+			expect(result).toEqual({ total: 0, missing: 0, updated: 0 });
 		});
 
 		it("should refuse on Better Auth < 1.7 (no account.issuer field)", async () => {
@@ -676,6 +684,9 @@ describe("firebaseAuthPlugin", () => {
 			expect(ctx.logger.warn).toHaveBeenCalledOnce();
 			const message = ctx.logger.warn.mock.calls[0][0] as string;
 			expect(message).toContain("3 of 5");
+			expect(message).toContain(
+				"npx better-auth-firebase-auth backfill-account-issuers",
+			);
 			expect(message).toContain("backfillAccountIssuers");
 			expect(message).toContain(FIREBASE_ACCOUNT_ISSUER);
 			expect(message).toContain("migrationChecks: false");
@@ -1314,10 +1325,10 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 		});
 
 		const dry = await backfillAccountIssuers(auth as any, { dryRun: true });
-		expect(dry).toEqual({ total: 1, updated: 0 });
+		expect(dry).toEqual({ total: 1, missing: 1, updated: 0 });
 
 		const result = await backfillAccountIssuers(auth as any);
-		expect(result).toEqual({ total: 1, updated: 1 });
+		expect(result).toEqual({ total: 1, missing: 1, updated: 1 });
 
 		// The stamped row is found by (issuer, accountId) again: same user, no duplicate.
 		const res2 = await client.$fetch("/firebase-auth/sign-in-with-google", {

--- a/src/firebase-auth-plugin.test.ts
+++ b/src/firebase-auth-plugin.test.ts
@@ -302,6 +302,7 @@ describe("firebaseAuthPlugin", () => {
 				expect(mockInternalAdapter.updateAccount).toHaveBeenCalledWith(
 					"account-456",
 					{
+						userId: "user-123",
 						idToken: "id-token-abc",
 						accessTokenExpiresAt: expect.any(Date),
 					},
@@ -463,7 +464,7 @@ describe("firebaseAuthPlugin", () => {
 				expect(modernAdapter.linkAccount).not.toHaveBeenCalled();
 				expect(modernAdapter.updateAccount).toHaveBeenCalledWith(
 					"account-456",
-					expect.any(Object),
+					expect.objectContaining({ userId: "user-123" }),
 				);
 			});
 		});
@@ -1089,5 +1090,45 @@ describe("integration: firebaseAuthPlugin with betterAuth", async () => {
 		const data2 = res2.data as any;
 		expect(data1.user.id).toBe(data2.user.id);
 		expect(data1.user.email).toBe(data2.user.email);
+	});
+
+	it("should re-parent an orphaned account when the user row was deleted", async () => {
+		const { client, auth } = await getTestInstance(
+			{
+				plugins: [
+					firebaseAuthPlugin({
+						firebaseAdminAuth: mockAdminAuth as any,
+					}),
+				],
+			},
+			{ disableTestUser: true },
+		);
+
+		const res1 = await client.$fetch("/firebase-auth/sign-in-with-google", {
+			method: "POST",
+			body: { idToken: "token-1" },
+		});
+		const firstUserId = (res1.data as any).user.id;
+
+		// Simulate a user row deleted without cascading to accounts.
+		const ctx = await (auth as any).$context;
+		await ctx.adapter.delete({
+			model: "user",
+			where: [{ field: "id", value: firstUserId }],
+		});
+
+		const res2 = await client.$fetch("/firebase-auth/sign-in-with-google", {
+			method: "POST",
+			body: { idToken: "token-2" },
+		});
+		const secondUserId = (res2.data as any).user.id;
+		expect(secondUserId).not.toBe(firstUserId);
+
+		const accounts = await ctx.adapter.findMany({
+			model: "account",
+			where: [{ field: "accountId", value: mockDecodedToken.uid }],
+		});
+		expect(accounts).toHaveLength(1);
+		expect((accounts[0] as any).userId).toBe(secondUserId);
 	});
 });

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -195,6 +195,7 @@ export const firebaseAuthPlugin = (
 		firebaseAdminAuth,
 		firebaseConfig,
 		sessionExpiresInDays = 7,
+		migrationChecks = true,
 		passwordResetUrl,
 		getPhoneUserFallbackEmail = ({ uid }) => `${uid}@firebase.local`,
 	} = options;
@@ -608,9 +609,62 @@ export const firebaseAuthPlugin = (
 
 	return {
 		id: "firebase-auth",
+		init: (ctx) => {
+			if (migrationChecks) {
+				// Fire and forget: never block or fail startup over a diagnostic.
+				void warnIfIssuerBackfillNeeded(ctx);
+			}
+		},
 		...(Object.keys(endpoints).length > 0 && { endpoints }),
 		...(hooks.before && hooks.before.length > 0 && { hooks }),
 	};
+};
+
+/**
+ * Log one startup warning when Better Auth 1.7 expects `account.issuer` but
+ * Firebase rows written by earlier versions still lack it — the symptom would
+ * otherwise be existing users silently losing their account link on sign-in.
+ * Two equality-only `count` reads; skipped on Better Auth < 1.7.
+ */
+const warnIfIssuerBackfillNeeded = async (ctx: {
+	tables?: { account?: { fields?: Record<string, unknown> } };
+	adapter: Pick<GenericEndpointContext["context"]["adapter"], "count">;
+	logger?: { warn: (message: string) => void };
+}): Promise<void> => {
+	try {
+		if (!ctx.tables?.account?.fields?.issuer) {
+			return; // Better Auth < 1.7 — accounts are not keyed by issuer yet.
+		}
+		const providerWhere = [
+			{ field: "providerId", value: FIREBASE_PROVIDER_ID },
+		];
+		const total = await ctx.adapter.count({
+			model: "account",
+			where: providerWhere,
+		});
+		if (total === 0) {
+			return;
+		}
+		const stamped = await ctx.adapter.count({
+			model: "account",
+			where: [
+				...providerWhere,
+				{ field: "issuer", value: FIREBASE_ACCOUNT_ISSUER },
+			],
+		});
+		const missing = total - stamped;
+		if (missing > 0) {
+			ctx.logger?.warn(
+				`[better-auth-firebase-auth] ${missing} of ${total} Firebase account rows have no issuer. ` +
+					`Better Auth 1.7 looks accounts up by (issuer, accountId), so those users' Firebase links are not found until backfilled. ` +
+					`Run: await backfillAccountIssuers(auth) from "better-auth-firebase-auth/server" — ` +
+					`or SQL: UPDATE account SET issuer = '${FIREBASE_ACCOUNT_ISSUER}' WHERE providerId = '${FIREBASE_PROVIDER_ID}'. ` +
+					`Set migrationChecks: false on firebaseAuthPlugin() to silence this check.`,
+			);
+		}
+	} catch {
+		// Diagnostics must never break auth startup.
+	}
 };
 
 export interface BackfillAccountIssuersResult {

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -141,6 +141,10 @@ export const createOrUpdateUser = async (
 		});
 	} else {
 		await internalAdapter.updateAccount(existingAccount.id, {
+			// Re-parent the row when its user was deleted (an "orphaned" account):
+			// without this it would keep pointing at the dead user id forever. For
+			// an owned account this writes the same value back.
+			userId: user.id,
 			idToken,
 			accessTokenExpiresAt: decodedToken.exp
 				? new Date(decodedToken.exp * 1000)

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -657,7 +657,8 @@ const warnIfIssuerBackfillNeeded = async (ctx: {
 			ctx.logger?.warn(
 				`[better-auth-firebase-auth] ${missing} of ${total} Firebase account rows have no issuer. ` +
 					`Better Auth 1.7 looks accounts up by (issuer, accountId), so those users' Firebase links are not found until backfilled. ` +
-					`Run: await backfillAccountIssuers(auth) from "better-auth-firebase-auth/server" — ` +
+					`Run: npx better-auth-firebase-auth backfill-account-issuers --apply — ` +
+					`or await backfillAccountIssuers(auth) from "better-auth-firebase-auth/server" — ` +
 					`or SQL: UPDATE account SET issuer = '${FIREBASE_ACCOUNT_ISSUER}' WHERE providerId = '${FIREBASE_PROVIDER_ID}'. ` +
 					`Set migrationChecks: false on firebaseAuthPlugin() to silence this check.`,
 			);
@@ -670,6 +671,8 @@ const warnIfIssuerBackfillNeeded = async (ctx: {
 export interface BackfillAccountIssuersResult {
 	/** Firebase account rows matched by `providerId = "firebase"`. */
 	total: number;
+	/** Rows whose `issuer` is not `FIREBASE_ACCOUNT_ISSUER` yet. */
+	missing: number;
 	/** Rows written (0 on a dry run). The write is idempotent. */
 	updated: number;
 }
@@ -722,8 +725,19 @@ export const backfillAccountIssuers = async (
 	const where = [{ field: "providerId", value: FIREBASE_PROVIDER_ID }];
 
 	const total = await adapter.count({ model: "account", where });
+	const stamped =
+		total === 0
+			? 0
+			: await adapter.count({
+					model: "account",
+					where: [
+						...where,
+						{ field: "issuer", value: FIREBASE_ACCOUNT_ISSUER },
+					],
+				});
+	const missing = total - stamped;
 	if (options?.dryRun) {
-		return { total, updated: 0 };
+		return { total, missing, updated: 0 };
 	}
 
 	const updated =
@@ -734,5 +748,5 @@ export const backfillAccountIssuers = async (
 					where,
 					update: { issuer: FIREBASE_ACCOUNT_ISSUER },
 				});
-	return { total, updated };
+	return { total, missing, updated };
 };

--- a/src/firebase-auth-plugin.ts
+++ b/src/firebase-auth-plugin.ts
@@ -612,3 +612,73 @@ export const firebaseAuthPlugin = (
 		...(hooks.before && hooks.before.length > 0 && { hooks }),
 	};
 };
+
+export interface BackfillAccountIssuersResult {
+	/** Firebase account rows matched by `providerId = "firebase"`. */
+	total: number;
+	/** Rows written (0 on a dry run). The write is idempotent. */
+	updated: number;
+}
+
+/**
+ * Stamp `issuer` on Firebase account rows created before Better Auth 1.7.
+ *
+ * Better Auth 1.7 looks accounts up by `(issuer, accountId)`; rows written by
+ * earlier versions have no `issuer`, so existing users' Firebase links are not
+ * found until it is set. This runs the backfill through the database adapter
+ * configured on your Better Auth instance, so it works on every database
+ * Better Auth supports and honors custom model/field names — no SQL required:
+ *
+ * ```ts
+ * import { auth } from "./lib/auth";
+ * import { backfillAccountIssuers } from "better-auth-firebase-auth/server";
+ *
+ * const { total, updated } = await backfillAccountIssuers(auth);
+ * ```
+ *
+ * Run it after upgrading better-auth to 1.7 and after `npx auth migrate` (or
+ * your ORM) added the nullable `issuer` column, and before making the column
+ * NOT NULL. On Better Auth < 1.7 it throws instead of silently writing
+ * nothing. Idempotent: rows already
+ * stamped are written with the same value, and rows corrupted to an empty
+ * string (the MySQL migration pitfall) are repaired.
+ */
+export const backfillAccountIssuers = async (
+	auth: {
+		$context: Promise<
+			Pick<GenericEndpointContext["context"], "adapter" | "tables">
+		>;
+	},
+	options?: { dryRun?: boolean },
+): Promise<BackfillAccountIssuersResult> => {
+	const { adapter, tables } = await auth.$context;
+
+	// On Better Auth < 1.7 the account model has no issuer field, so the
+	// adapter would silently drop the write and "succeed" without doing
+	// anything. Refuse instead of lying.
+	if (!tables.account?.fields?.issuer) {
+		throw new Error(
+			"backfillAccountIssuers requires Better Auth >= 1.7: the configured " +
+				"better-auth version has no account.issuer field. Upgrade " +
+				"better-auth (and add the nullable issuer column via `npx auth " +
+				"migrate` or your ORM) first.",
+		);
+	}
+
+	const where = [{ field: "providerId", value: FIREBASE_PROVIDER_ID }];
+
+	const total = await adapter.count({ model: "account", where });
+	if (options?.dryRun) {
+		return { total, updated: 0 };
+	}
+
+	const updated =
+		total === 0
+			? 0
+			: await adapter.updateMany({
+					model: "account",
+					where,
+					update: { issuer: FIREBASE_ACCOUNT_ISSUER },
+				});
+	return { total, updated };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,5 +2,10 @@ export {
 	extractOobCodeFromUrl,
 	firebaseAuthClientPlugin,
 } from "./firebase-auth-client-plugin.js";
-export { firebaseAuthPlugin } from "./firebase-auth-plugin.js";
+export {
+	type BackfillAccountIssuersResult,
+	backfillAccountIssuers,
+	FIREBASE_ACCOUNT_ISSUER,
+	firebaseAuthPlugin,
+} from "./firebase-auth-plugin.js";
 export type * from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,15 @@ export interface FirebaseAuthPluginOptions {
 	firebaseAdminAuth?: Auth;
 	firebaseConfig?: FirebaseOptions;
 	sessionExpiresInDays?: number;
+	/**
+	 * On startup, count Firebase account rows that still lack the Better Auth
+	 * 1.7 `issuer` value and log one warning with the exact remediation when
+	 * any are found (two equality-only `count` reads per process; skipped
+	 * entirely on Better Auth < 1.7). Set to `false` to disable.
+	 *
+	 * @default true
+	 */
+	migrationChecks?: boolean;
 	passwordResetUrl?: string;
 	/**
 	 * Generate a stable synthetic email for phone-only Firebase users who have

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,10 +5,11 @@
     "declaration": true,
     "emitDeclarationOnly": false,
     "module": "NodeNext",
-    "target": "ES2020",
+    "target": "ES2022",
     "moduleResolution": "NodeNext",
     "rootDir": "src",
-    "noEmit": false
+    "noEmit": false,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["src/**/*.test.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "declaration": true,
     "isolatedModules": true,
     "noEmit": true,
-    "types": ["vitest/globals"]
+    "types": ["vitest/globals", "node"]
   },
   "include": ["src", "tests", "examples"],
   "exclude": ["dist", "node_modules"]


### PR DESCRIPTION
Four follow-ups to v2.2.0, one commit each so each renders as its own line in the release notes (four `fix` commits → **v2.2.1**; everything here is additive and cannot break any 2.x consumer, and 2.2.0 is days old with effectively no adopters, so patch scope is a deliberate labeling choice).

## 1. Re-parent orphaned Firebase accounts

When a Better Auth user row is deleted without cascading to `account` (manual cleanup, external tooling), the surviving Firebase account row kept pointing at the dead user id forever — sign-in resolved a user by email (or created one) and refreshed the row's tokens but never its owner. 1.7's `findAccountOwnerByKey` made the state visible (`kind: "orphaned"`); the bug predates 1.7 and existed on the 1.5/1.6 path too. Fix: `updateAccount` now includes `userId: user.id` (a same-value write for normally owned accounts). Proven end to end: sign in → delete the user row via the raw adapter → sign in again → the *same* account row (no duplicate) points at the new user.

## 2. `backfillAccountIssuers(auth)`

The v2.2.0 upgrade notes hand consumers a raw `UPDATE` — which presumes a SQL database, correct dialect quoting, and default field names. This plugin can't ship an `npx` CLI the way `better-auth-firestore` does (the plugin never sees your database; better-auth owns that config), but it can go through the configured adapter at runtime:

```ts
import { auth } from "./lib/auth";
import { backfillAccountIssuers } from "better-auth-firebase-auth/server";

const { total, updated } = await backfillAccountIssuers(auth); // { dryRun: true } to count only
```

Works on every database better-auth supports (including schemaless), honors custom `modelName`/`fieldName`, idempotent, repairs MySQL empty-string corruption, and **throws a clear error on Better Auth < 1.7** (where the adapter would otherwise drop the unknown field and "succeed" silently). README now documents both paths and exactly where to run the SQL variant.

## 3. Startup warning while the backfill is missing

The failure mode of a missed backfill is quiet — sign-in keeps working via the email fallback while account links silently stay orphaned. Mirroring `better-auth-firestore`'s migration check: on init (Better Auth ≥ 1.7 only), the plugin compares `count(providerId='firebase')` against `count(providerId='firebase' AND issuer='local:oauth:firebase')` and logs one warning naming the missing count and the exact remediation. Two equality-only `count` reads per process, works on every adapter, fire-and-forget (can never block or break startup), `migrationChecks: false` disables it. (Commit 4 adds the `npx` command on top by loading the app's config the way `npx auth` does.)

## 4. `npx better-auth-firebase-auth backfill-account-issuers`

The CLI parity with `better-auth-firestore` after all — solved the way `npx auth migrate` solves it: the command searches the same config locations as Better Auth's own CLI (or takes `--config`), imports the file exporting your `betterAuth(...)` instance, and runs the backfill through its adapter. Dry run by default, `--apply` writes, exit 1 if rows remain missing. Zero new runtime dependencies: the config loads via `jiti` when the project has it, else Node's native TypeScript type stripping (Node ≥ 22.18; engines is ≥ 22). `backfillAccountIssuers` now also reports `missing` alongside `total`/`updated`, and the startup warning names the npx command first. `verify:pack` executes the installed bin from the packed tarball (help + a functional dry run) in CI. Verified end to end on a scratch app: TS config imported natively (no jiti), legacy row reported, stamped by `--apply`, confirmed in SQLite.

## Testing

89/89 on better-auth **1.7.1, 1.6.30 and 1.5.6** (end-to-end tests for the re-parenting and the backfill; on 1.5/1.6 the backfill test asserts the refusal; the warning is covered for warn/silent/pre-1.7/disabled/adapter-failure). Build on TS 7.0.2, `verify:pack` green.

## Merging

**Rebase and merge** — four lines in the notes, patch bump. After v2.2.1 publishes, append to the release body:

<details>
<summary>Release notes to append after publish</summary>

```markdown
## Upgrade notes

- **The 1.7 `issuer` backfill is now one command** — `npx better-auth-firebase-auth backfill-account-issuers` (dry run; add `--apply` to write). It finds and imports your `betterAuth(...)` config like `npx auth migrate` does and runs through your database adapter. Also available programmatically: `await backfillAccountIssuers(auth)` from `better-auth-firebase-auth/server`; the SQL variant remains in the [README](https://github.com/yultyyev/better-auth-firebase-auth#upgrading-an-existing-app-to-better-auth-17).
- **Orphaned accounts self-heal on sign-in** — if a user row was deleted but its Firebase account row survived, sign-in now re-points that row at the resolved user instead of leaving it on the dead user id.
- **The plugin now warns at startup** (Better Auth ≥ 1.7) while Firebase account rows still lack an `issuer`, naming the exact backfill command — `migrationChecks: false` disables the check.
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
